### PR TITLE
feat(auth): multi-client onboarding module (B.1)

### DIFF
--- a/adr/008-multi-tenant-client-isolation.md
+++ b/adr/008-multi-tenant-client-isolation.md
@@ -1,0 +1,69 @@
+# ADR-008: Multi-Tenant Client Isolation via Per-Team Cognito App Clients
+
+**Status**: Accepted
+**Date**: 2026-03-20
+**Deciders**: AI Engineering NAMER
+
+## Context
+
+The AI Gateway's authentication layer (ADR-005, ADR-007) uses a single Cognito User Pool with ALB JWT validation. Currently, there is exactly one hardcoded M2M app client (`gateway_m2m`) that all consumers share.
+
+This single-client model creates several problems as adoption grows:
+
+- **No credential isolation**: If one team's credentials are compromised, all teams are affected and the shared credential must be rotated.
+- **No per-team audit trail**: CloudTrail and Cognito logs show the same `client_id` for every request, making it impossible to attribute usage to specific teams.
+- **No per-team scope control**: Every consumer gets the same OAuth scopes. There is no way to grant `admin` scope to the platform team while limiting other teams to `invoke` only.
+- **No independent rotation**: Rotating credentials requires coordinating with every consumer simultaneously.
+
+## Decision
+
+Introduce a `clients` Terraform module (`infrastructure/modules/clients/`) that creates per-team Cognito app clients from a configurable map (`client_configs`). Each team gets:
+
+- Its own `aws_cognito_user_pool_client` with `client_credentials` grant
+- Team-specific OAuth scopes (subset of the resource server's available scopes)
+- Independent client ID and secret for credential rotation
+
+The module is opt-in: it only creates resources when `client_configs` is non-empty. The existing `gateway_m2m` client in the auth module is preserved for backward compatibility.
+
+### Configuration Example
+
+```hcl
+client_configs = {
+  platform = {
+    allowed_scopes = ["https://gateway.internal/invoke", "https://gateway.internal/admin"]
+    description    = "Platform engineering team"
+  }
+  ml-training = {
+    allowed_scopes = ["https://gateway.internal/invoke"]
+    description    = "ML training pipeline service account"
+  }
+}
+```
+
+## Consequences
+
+**Positive**:
+- Credential compromise is isolated to one team; other teams are unaffected.
+- Per-team `client_id` in JWT claims enables attribution in CloudTrail, ALB access logs, and application-layer metrics.
+- Teams can be granted different scope sets (e.g., only platform gets `admin`).
+- Credential rotation is per-team with no cross-team coordination.
+- Adding or removing a team is a single Terraform variable change.
+
+**Negative**:
+- Client lifecycle management is now required: teams must be onboarded/offboarded via Terraform.
+- The number of Cognito app clients grows linearly with teams (Cognito supports up to 1,000 per user pool, which is sufficient).
+- Client secrets are stored in Terraform state; state encryption and access controls must be enforced.
+
+## Alternatives Considered
+
+| Approach | Verdict |
+|---|---|
+| API keys at application layer | Rejected: duplicates Cognito's capability, no JWT validation at ALB |
+| Single client + custom claims Lambda | Rejected: still shares credentials, adds Lambda cold-start latency |
+| Separate Cognito User Pool per team | Rejected: over-isolated, complicates ALB listener config (one JWKS per pool) |
+
+## Sources
+
+- ADR-005: ALB JWT Validation Over API Gateway
+- ADR-007: Terraform Provider Upgrade for JWT
+- [Cognito quotas: App clients per user pool](https://docs.aws.amazon.com/cognito/latest/developerguide/limits.html) (1,000 default)

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -59,6 +59,21 @@ module "auth" {
 }
 
 # -----------------------------------------------------------------------------
+# Clients (per-team Cognito app clients -- only created if client_configs is set)
+# -----------------------------------------------------------------------------
+
+module "clients" {
+  source = "./modules/clients"
+  count  = length(var.client_configs) > 0 ? 1 : 0
+
+  project_name                      = var.project_name
+  environment                       = var.environment
+  user_pool_id                      = module.auth.cognito_user_pool_id
+  resource_server_scope_identifiers = module.auth.resource_server_scope_identifiers
+  client_configs                    = var.client_configs
+}
+
+# -----------------------------------------------------------------------------
 # Compute (needs VPC subnets, ALB SG + target group, log group names)
 # -----------------------------------------------------------------------------
 

--- a/infrastructure/modules/auth/outputs.tf
+++ b/infrastructure/modules/auth/outputs.tf
@@ -17,3 +17,8 @@ output "cognito_token_endpoint" {
   description = "Cognito token endpoint URL"
   value       = "https://${aws_cognito_user_pool_domain.gateway.domain}.auth.${var.aws_region}.amazoncognito.com/oauth2/token"
 }
+
+output "resource_server_scope_identifiers" {
+  description = "List of fully-qualified scope identifiers from the Cognito resource server"
+  value       = aws_cognito_resource_server.gateway.scope_identifiers
+}

--- a/infrastructure/modules/clients/main.tf
+++ b/infrastructure/modules/clients/main.tf
@@ -1,0 +1,29 @@
+# =============================================================================
+# Clients — Per-team Cognito App Clients for Multi-Tenant M2M Access
+#
+# Creates isolated Cognito user pool clients from a configurable map.
+# Each team gets its own client_credentials grant with scoped OAuth access.
+# =============================================================================
+
+resource "aws_cognito_user_pool_client" "team" {
+  # checkov:skip=CKV_TF_1: Using local modules, not registry
+  for_each = var.client_configs
+
+  name         = "${var.project_name}-${each.key}-${var.environment}"
+  user_pool_id = var.user_pool_id
+
+  generate_secret                      = true
+  allowed_oauth_flows_user_pool_client = true
+  allowed_oauth_flows                  = ["client_credentials"]
+
+  allowed_oauth_scopes = [
+    for scope in each.value.allowed_scopes :
+    contains(var.resource_server_scope_identifiers, scope) ? scope : scope
+  ]
+
+  access_token_validity = 1
+
+  token_validity_units {
+    access_token = "hours"
+  }
+}

--- a/infrastructure/modules/clients/outputs.tf
+++ b/infrastructure/modules/clients/outputs.tf
@@ -1,0 +1,24 @@
+output "client_ids" {
+  description = "Map of team name to Cognito app client ID"
+  value = {
+    for team, client in aws_cognito_user_pool_client.team :
+    team => client.id
+  }
+}
+
+output "client_secrets" {
+  description = "Map of team name to Cognito app client secret"
+  sensitive   = true
+  value = {
+    for team, client in aws_cognito_user_pool_client.team :
+    team => client.client_secret
+  }
+}
+
+output "client_names" {
+  description = "Map of team name to Cognito app client name"
+  value = {
+    for team, client in aws_cognito_user_pool_client.team :
+    team => client.name
+  }
+}

--- a/infrastructure/modules/clients/variables.tf
+++ b/infrastructure/modules/clients/variables.tf
@@ -1,0 +1,38 @@
+variable "user_pool_id" {
+  description = "Cognito User Pool ID to create clients in"
+  type        = string
+}
+
+variable "resource_server_scope_identifiers" {
+  description = "List of valid scope identifiers from the Cognito resource server (e.g. https://gateway.internal/invoke)"
+  type        = list(string)
+}
+
+variable "client_configs" {
+  description = <<-EOT
+    Map of team configurations for Cognito app clients.
+    Each key is the team identifier used in resource naming.
+
+    Example:
+      client_configs = {
+        platform = {
+          allowed_scopes = ["https://gateway.internal/invoke"]
+          description    = "Platform engineering team"
+        }
+      }
+  EOT
+  type = map(object({
+    allowed_scopes = list(string)
+    description    = string
+  }))
+}
+
+variable "project_name" {
+  description = "Project name used for resource naming"
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment (dev or prod)"
+  type        = string
+}

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -46,3 +46,18 @@ output "cognito_token_endpoint" {
   description = "Cognito token endpoint URL"
   value       = module.auth.cognito_token_endpoint
 }
+
+# -----------------------------------------------------------------------------
+# Multi-Client Outputs
+# -----------------------------------------------------------------------------
+
+output "team_client_ids" {
+  description = "Map of team name to Cognito app client ID (empty if no client_configs)"
+  value       = length(module.clients) > 0 ? module.clients[0].client_ids : {}
+}
+
+output "team_client_secrets" {
+  description = "Map of team name to Cognito app client secret (empty if no client_configs)"
+  sensitive   = true
+  value       = length(module.clients) > 0 ? module.clients[0].client_secrets : {}
+}

--- a/infrastructure/variables_clients.tf
+++ b/infrastructure/variables_clients.tf
@@ -1,0 +1,24 @@
+variable "client_configs" {
+  description = <<-EOT
+    Map of team configurations for per-team Cognito app clients.
+    Each key is the team identifier; value specifies allowed OAuth scopes
+    and a human-readable description.
+
+    Example:
+      client_configs = {
+        platform = {
+          allowed_scopes = ["https://gateway.internal/invoke"]
+          description    = "Platform engineering team"
+        }
+        ml-ops = {
+          allowed_scopes = ["https://gateway.internal/invoke", "https://gateway.internal/admin"]
+          description    = "ML Operations team"
+        }
+      }
+  EOT
+  type = map(object({
+    allowed_scopes = list(string)
+    description    = string
+  }))
+  default = {}
+}

--- a/scripts/onboard-client.sh
+++ b/scripts/onboard-client.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# onboard-client.sh -- Retrieve Cognito credentials for an onboarded team.
+#
+# Reads terraform output to extract the client ID, client secret, and token
+# endpoint for a given team name.
+#
+# Usage:
+#   ./onboard-client.sh <team-name>
+#
+# Prerequisites:
+#   - Terraform state is accessible (run from infrastructure/ or use -chdir)
+#   - The team must already exist in client_configs and have been applied
+#
+# Exit codes:
+#   0  success
+#   1  missing argument or team not found
+#   2  terraform command failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INFRA_DIR="${SCRIPT_DIR}/../infrastructure"
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $(basename "$0") <team-name>" >&2
+  echo "example: $(basename "$0") platform" >&2
+  exit 1
+fi
+
+TEAM_NAME="$1"
+
+echo "Fetching Terraform outputs for team '${TEAM_NAME}'..." >&2
+
+client_ids_json=$(terraform -chdir="${INFRA_DIR}" output -json team_client_ids 2>/dev/null) || {
+  echo "error: failed to read terraform output 'team_client_ids'" >&2
+  echo "hint:  ensure you have run 'terraform apply' and have access to state" >&2
+  exit 2
+}
+
+client_secrets_json=$(terraform -chdir="${INFRA_DIR}" output -json team_client_secrets 2>/dev/null) || {
+  echo "error: failed to read terraform output 'team_client_secrets'" >&2
+  exit 2
+}
+
+token_endpoint=$(terraform -chdir="${INFRA_DIR}" output -raw cognito_token_endpoint 2>/dev/null) || {
+  echo "error: failed to read terraform output 'cognito_token_endpoint'" >&2
+  exit 2
+}
+
+client_id=$(python3 -c "
+import json, sys
+data = json.loads(sys.argv[1])
+team = sys.argv[2]
+if team not in data:
+    print(f\"error: team '{team}' not found in client_ids\", file=sys.stderr)
+    print(f\"available teams: {', '.join(sorted(data.keys())) or '(none)'}\", file=sys.stderr)
+    sys.exit(1)
+print(data[team], end='')
+" "${client_ids_json}" "${TEAM_NAME}") || exit 1
+
+client_secret=$(python3 -c "
+import json, sys
+data = json.loads(sys.argv[1])
+team = sys.argv[2]
+if team not in data:
+    print(f\"error: team '{team}' not found in client_secrets\", file=sys.stderr)
+    sys.exit(1)
+print(data[team], end='')
+" "${client_secrets_json}" "${TEAM_NAME}") || exit 1
+
+printf '\n=== AI Gateway Credentials: %s ===\n\n' "${TEAM_NAME}"
+printf '  Client ID:      %s\n' "${client_id}"
+printf '  Client Secret:  %s\n' "${client_secret}"
+printf '  Token Endpoint: %s\n' "${token_endpoint}"
+printf '\n--- Quick test ---\n\n'
+printf '  export GATEWAY_CLIENT_ID="%s"\n' "${client_id}"
+printf '  export GATEWAY_CLIENT_SECRET="%s"\n' "${client_secret}"
+printf '  export GATEWAY_TOKEN_ENDPOINT="%s"\n' "${token_endpoint}"
+printf '  ./scripts/get-gateway-token.sh\n\n'


### PR DESCRIPTION
## Summary
- New `infrastructure/modules/clients/` Terraform module that creates per-team Cognito app clients from a configurable `client_configs` map
- Each team gets isolated `client_credentials` grant with scoped OAuth access
- `scripts/onboard-client.sh` helper for retrieving team credentials from Terraform outputs
- ADR-008: Multi-Tenant Client Isolation Strategy

## Files Changed
- `infrastructure/modules/clients/` — new module (main.tf, variables.tf, outputs.tf)
- `infrastructure/main.tf` — wires clients module to auth outputs
- `infrastructure/outputs.tf` — adds team_client_ids and team_client_secrets outputs
- `infrastructure/modules/auth/outputs.tf` — exposes resource_server_scope_identifiers
- `infrastructure/variables_clients.tf` — root-level client_configs variable
- `scripts/onboard-client.sh` — onboarding helper script
- `adr/008-multi-tenant-client-isolation.md` — architectural decision record

## Usage
```hcl
client_configs = {
  team-alpha = {
    allowed_scopes = ["https://gateway.internal/invoke"]
    description    = "Team Alpha - coding agents"
  }
  team-beta = {
    allowed_scopes = ["https://gateway.internal/invoke", "https://gateway.internal/admin"]
    description    = "Team Beta - platform team"
  }
}
```

## Test plan
- [x] `terraform validate` passes
- [ ] `terraform plan` with sample client_configs shows correct resources
- [ ] Onboard script outputs correct credentials format