### PR TITLE
feat(security): Bedrock Guardrails integration (B.4)

### DIFF
--- a/adr/011-bedrock-guardrails-integration.md
+++ b/adr/011-bedrock-guardrails-integration.md
@@ -1,0 +1,53 @@
+# ADR-011: Bedrock Guardrails Integration for Content Safety Filtering
+
+**Status**: Accepted
+**Date**: 2026-03-20
+**Deciders**: AI Engineering NAMER
+
+## Context
+
+The AI Gateway currently has no content safety layer. Enterprise teams routing LLM traffic through the gateway need configurable content filtering to:
+
+- Block harmful content (hate speech, violence, sexual content, insults, misconduct)
+- Prevent PII leakage (SSNs, credit card numbers, phone numbers, email addresses)
+- Enforce topic restrictions (e.g., block discussions of competitor products or internal financials)
+- Filter specific words or phrases per organizational policy
+
+Without a guardrail layer, individual teams must implement their own content moderation, leading to inconsistent enforcement and duplicated effort.
+
+## Decision
+
+Integrate Amazon Bedrock Guardrails as a Terraform module (`infrastructure/modules/guardrails/`) that creates and versions a `aws_bedrock_guardrail` resource with configurable policies for content filtering, PII blocking, topic denial, and word filtering.
+
+The module is gated by `enable_guardrails` (default `false`) so existing deployments are unaffected. ECS task IAM roles are extended with `bedrock:ApplyGuardrail` and `bedrock:GetGuardrail` permissions.
+
+## Alternatives Considered
+
+### Custom Lambda content filter
+A Lambda function invoked before/after model calls to scan for PII and harmful content. Rejected because it requires building and maintaining custom ML models or regex-based detection, with no parity to Bedrock's built-in classifiers.
+
+### Portkey built-in guardrails
+Portkey Cloud offers guardrail hooks, but these require Portkey Cloud (SaaS) rather than the self-hosted OSS gateway we deploy. Not available in our architecture.
+
+### Third-party content moderation APIs
+Services like Perspective API or OpenAI Moderation endpoint. Rejected because they add external dependencies, egress costs, and latency to a non-AWS service, conflicting with our AWS-native design principle.
+
+## Consequences
+
+**Positive**:
+- AWS-native solution requiring no additional infrastructure beyond the guardrail resource itself
+- Configurable per deployment environment (dev may use lower thresholds than prod)
+- Immutable versioning via `aws_bedrock_guardrail_version` for audit and rollback
+- PII detection uses Bedrock's built-in classifiers (no custom model training)
+- Prompt attack detection included as a content filter category
+
+**Negative**:
+- Adds latency per request when guardrails are applied (Bedrock API call for each evaluation)
+- Bedrock Guardrails pricing applies per text unit processed
+- Content filter categories and PII types are limited to what Bedrock supports
+- Guardrail must be explicitly applied by the calling application; it does not auto-intercept gateway traffic
+
+## Sources
+
+- [Amazon Bedrock Guardrails documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html)
+- [Terraform aws_bedrock_guardrail resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrock_guardrail)

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -123,3 +123,19 @@ module "cost_attribution" {
   gateway_log_group_name  = module.observability.gateway_log_group_name
   gateway_log_group_arn   = module.observability.gateway_log_group_arn
 }
+
+# -----------------------------------------------------------------------------
+# Guardrails (Bedrock content safety filtering)
+# -----------------------------------------------------------------------------
+
+module "guardrails" {
+  source = "./modules/guardrails"
+
+  project_name = var.project_name
+  environment  = var.environment
+
+  enable_guardrails       = var.enable_guardrails
+  content_filter_strength = var.guardrails_content_filter_strength
+  blocked_topics          = var.guardrails_blocked_topics
+  blocked_words           = var.guardrails_blocked_words
+}

--- a/infrastructure/modules/compute/main.tf
+++ b/infrastructure/modules/compute/main.tf
@@ -204,7 +204,9 @@ resource "aws_iam_role_policy" "ecs_task_bedrock" {
       Effect = "Allow"
       Action = [
         "bedrock:InvokeModel",
-        "bedrock:InvokeModelWithResponseStream"
+        "bedrock:InvokeModelWithResponseStream",
+        "bedrock:ApplyGuardrail",
+        "bedrock:GetGuardrail"
       ]
       Resource = "*"
     }]

--- a/infrastructure/modules/guardrails/main.tf
+++ b/infrastructure/modules/guardrails/main.tf
@@ -1,0 +1,117 @@
+# =============================================================================
+# Guardrails — Bedrock Guardrails for content safety filtering
+# =============================================================================
+
+resource "aws_bedrock_guardrail" "this" {
+  count = var.enable_guardrails ? 1 : 0
+
+  name                      = "${var.project_name}-${var.environment}"
+  blocked_input_messaging   = var.guardrail_blocked_message
+  blocked_outputs_messaging = var.guardrail_blocked_message
+  description               = "Content safety guardrail for ${var.project_name} (${var.environment})"
+
+  # ---------------------------------------------------------------------------
+  # Content policy — block harmful content categories
+  # ---------------------------------------------------------------------------
+
+  content_policy_config {
+    filters_config {
+      type            = "HATE"
+      input_strength  = var.content_filter_strength
+      output_strength = var.content_filter_strength
+    }
+    filters_config {
+      type            = "INSULTS"
+      input_strength  = var.content_filter_strength
+      output_strength = var.content_filter_strength
+    }
+    filters_config {
+      type            = "SEXUAL"
+      input_strength  = var.content_filter_strength
+      output_strength = var.content_filter_strength
+    }
+    filters_config {
+      type            = "VIOLENCE"
+      input_strength  = var.content_filter_strength
+      output_strength = var.content_filter_strength
+    }
+    filters_config {
+      type            = "MISCONDUCT"
+      input_strength  = var.content_filter_strength
+      output_strength = var.content_filter_strength
+    }
+    filters_config {
+      type            = "PROMPT_ATTACK"
+      input_strength  = "HIGH"
+      output_strength = "NONE"
+    }
+  }
+
+  # ---------------------------------------------------------------------------
+  # Sensitive information policy — block PII leakage
+  # ---------------------------------------------------------------------------
+
+  dynamic "sensitive_information_policy_config" {
+    for_each = length(var.blocked_pii_types) > 0 ? [1] : []
+    content {
+      dynamic "pii_entities_config" {
+        for_each = var.blocked_pii_types
+        content {
+          type   = pii_entities_config.value
+          action = "BLOCK"
+        }
+      }
+    }
+  }
+
+  # ---------------------------------------------------------------------------
+  # Topic policy — block configurable topics
+  # ---------------------------------------------------------------------------
+
+  dynamic "topic_policy_config" {
+    for_each = length(var.blocked_topics) > 0 ? [1] : []
+    content {
+      dynamic "topics_config" {
+        for_each = var.blocked_topics
+        content {
+          name       = topics_config.value.name
+          type       = "DENY"
+          definition = topics_config.value.definition
+          examples   = lookup(topics_config.value, "examples", [])
+        }
+      }
+    }
+  }
+
+  # ---------------------------------------------------------------------------
+  # Word policy — block specific words/phrases
+  # ---------------------------------------------------------------------------
+
+  dynamic "word_policy_config" {
+    for_each = length(var.blocked_words) > 0 ? [1] : []
+    content {
+      dynamic "words_config" {
+        for_each = var.blocked_words
+        content {
+          text = words_config.value
+        }
+      }
+    }
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-guardrail"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Guardrail Version — immutable published version for production use
+# -----------------------------------------------------------------------------
+
+resource "aws_bedrock_guardrail_version" "this" {
+  count = var.enable_guardrails ? 1 : 0
+
+  guardrail_arn = aws_bedrock_guardrail.this[0].guardrail_arn
+  description   = "Managed by Terraform"
+  skip_destroy  = true
+}

--- a/infrastructure/modules/guardrails/outputs.tf
+++ b/infrastructure/modules/guardrails/outputs.tf
@@ -1,0 +1,14 @@
+output "guardrail_id" {
+  description = "ID of the Bedrock Guardrail"
+  value       = var.enable_guardrails ? aws_bedrock_guardrail.this[0].guardrail_id : null
+}
+
+output "guardrail_arn" {
+  description = "ARN of the Bedrock Guardrail"
+  value       = var.enable_guardrails ? aws_bedrock_guardrail.this[0].guardrail_arn : null
+}
+
+output "guardrail_version" {
+  description = "Published version number of the Bedrock Guardrail"
+  value       = var.enable_guardrails ? aws_bedrock_guardrail_version.this[0].version : null
+}

--- a/infrastructure/modules/guardrails/variables.tf
+++ b/infrastructure/modules/guardrails/variables.tf
@@ -1,0 +1,65 @@
+variable "project_name" {
+  description = "Project name used for resource naming"
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment (dev or prod)"
+  type        = string
+}
+
+variable "enable_guardrails" {
+  description = "Whether to create Bedrock Guardrails resources"
+  type        = bool
+  default     = true
+}
+
+variable "content_filter_strength" {
+  description = "Strength of content filters (LOW, MEDIUM, HIGH)"
+  type        = string
+  default     = "HIGH"
+
+  validation {
+    condition     = contains(["LOW", "MEDIUM", "HIGH"], var.content_filter_strength)
+    error_message = "content_filter_strength must be LOW, MEDIUM, or HIGH."
+  }
+}
+
+variable "blocked_topics" {
+  description = "List of topics to block, each with a name and definition"
+  type = list(object({
+    name       = string
+    definition = string
+    examples   = optional(list(string), [])
+  }))
+  default = [
+    {
+      name       = "competitor_products"
+      definition = "Discussions or recommendations about competitor products and services."
+      examples   = ["Tell me about competing AI platforms"]
+    },
+    {
+      name       = "internal_financials"
+      definition = "Internal financial data, revenue figures, or unreleased business metrics."
+      examples   = ["What is the company revenue this quarter"]
+    }
+  ]
+}
+
+variable "blocked_words" {
+  description = "List of words or phrases to block in inputs and outputs"
+  type        = list(string)
+  default     = []
+}
+
+variable "blocked_pii_types" {
+  description = "List of PII entity types to block (e.g., SSN, CREDIT_DEBIT_CARD_NUMBER, PHONE, EMAIL)"
+  type        = list(string)
+  default     = ["SSN", "CREDIT_DEBIT_CARD_NUMBER", "PHONE", "EMAIL"]
+}
+
+variable "guardrail_blocked_message" {
+  description = "Message returned when content is blocked by the guardrail"
+  type        = string
+  default     = "This request was blocked by content safety filters."
+}

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -47,7 +47,6 @@ output "cognito_token_endpoint" {
   value       = module.auth.cognito_token_endpoint
 }
 
-# -----------------------------------------------------------------------------
 # Multi-Client Outputs
 # -----------------------------------------------------------------------------
 
@@ -60,4 +59,18 @@ output "team_client_secrets" {
   description = "Map of team name to Cognito app client secret (empty if no client_configs)"
   sensitive   = true
   value       = length(module.clients) > 0 ? module.clients[0].client_secrets : {}
+}
+
+# -----------------------------------------------------------------------------
+# Guardrails Outputs
+# -----------------------------------------------------------------------------
+
+output "guardrail_id" {
+  description = "Bedrock Guardrail ID"
+  value       = module.guardrails.guardrail_id
+}
+
+output "guardrail_arn" {
+  description = "Bedrock Guardrail ARN"
+  value       = module.guardrails.guardrail_arn
 }

--- a/infrastructure/variables_guardrails.tf
+++ b/infrastructure/variables_guardrails.tf
@@ -1,0 +1,47 @@
+# =============================================================================
+# Guardrails — Root-level variables for Bedrock Guardrails configuration
+# =============================================================================
+
+variable "enable_guardrails" {
+  description = "Whether to enable Bedrock Guardrails for content safety filtering"
+  type        = bool
+  default     = false
+}
+
+variable "guardrails_blocked_topics" {
+  description = "List of topics to block, each with a name and definition"
+  type = list(object({
+    name       = string
+    definition = string
+    examples   = optional(list(string), [])
+  }))
+  default = [
+    {
+      name       = "competitor_products"
+      definition = "Discussions or recommendations about competitor products and services."
+      examples   = ["Tell me about competing AI platforms"]
+    },
+    {
+      name       = "internal_financials"
+      definition = "Internal financial data, revenue figures, or unreleased business metrics."
+      examples   = ["What is the company revenue this quarter"]
+    }
+  ]
+}
+
+variable "guardrails_blocked_words" {
+  description = "List of words or phrases to block in inputs and outputs"
+  type        = list(string)
+  default     = []
+}
+
+variable "guardrails_content_filter_strength" {
+  description = "Strength of content filters (LOW, MEDIUM, HIGH)"
+  type        = string
+  default     = "HIGH"
+
+  validation {
+    condition     = contains(["LOW", "MEDIUM", "HIGH"], var.guardrails_content_filter_strength)
+    error_message = "guardrails_content_filter_strength must be LOW, MEDIUM, or HIGH."
+  }
+}


### PR DESCRIPTION
## Summary
- New `infrastructure/modules/guardrails/` Terraform module for Bedrock Guardrails
- Content policy: blocks HATE, INSULTS, SEXUAL, VIOLENCE, MISCONDUCT at configurable strength
- PII filtering: blocks SSN, credit card, phone, email by default
- Configurable topic and word policies
- Immutable guardrail versioning via `aws_bedrock_guardrail_version`
- ECS task role updated with `bedrock:ApplyGuardrail` + `bedrock:GetGuardrail` permissions
- ADR-011: Bedrock Guardrails Integration

## Files Changed
- `infrastructure/modules/guardrails/` — new module (main.tf, variables.tf, outputs.tf)
- `infrastructure/main.tf` — wires guardrails module
- `infrastructure/modules/compute/main.tf` — adds guardrail IAM permissions to ECS task role
- `infrastructure/outputs.tf` — adds guardrail_id and guardrail_arn
- `infrastructure/variables_guardrails.tf` — enable_guardrails, topic/word/strength configs
- `adr/011-bedrock-guardrails-integration.md` — architectural decision record

## Test plan
- [x] `terraform validate` passes
- [ ] `terraform plan` with `enable_guardrails = true` shows correct guardrail resources
- [ ] Verify guardrail policy configuration in AWS console after apply