### PR TITLE
feat(infra): ElastiCache Redis response cache layer (B.5)

### DIFF
--- a/adr/012-response-cache-strategy.md
+++ b/adr/012-response-cache-strategy.md
@@ -1,0 +1,54 @@
+# ADR-012: Response Cache Strategy with ElastiCache Redis
+
+**Status**: Accepted
+**Date**: 2026-03-20
+**Deciders**: AI Engineering NAMER
+
+## Context
+
+Every request to the AI Gateway currently hits upstream LLM providers directly. There is no response caching layer, which means:
+
+- Identical prompts (common in testing, retries, and templated workflows) incur full provider costs each time.
+- Latency for repeated queries is unnecessarily high.
+- During load spikes, all traffic fans out to providers with no local absorption.
+
+Portkey Gateway OSS has built-in support for response caching via a Redis backend, activated by setting `CACHE_STORE=redis` and `REDIS_URL` environment variables.
+
+## Decision
+
+Deploy an Amazon ElastiCache Redis cluster within the existing VPC private subnets and configure the Portkey Gateway to use it for exact-match response caching.
+
+### Configuration
+
+- **Engine**: Redis 7.1 (ElastiCache)
+- **Node type**: `cache.t4g.micro` (single-node for dev, scalable for prod)
+- **Eviction**: `allkeys-lru` (least recently used eviction when memory is full)
+- **Encryption**: At-rest and in-transit (TLS) enabled
+- **Network**: Private subnets only; security group allows TCP 6379 from ECS tasks only
+
+## Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| **ElastiCache Redis** (chosen) | Native Portkey support; sub-ms latency; mature managed service; LRU eviction built in | Additional infrastructure; no semantic matching |
+| DynamoDB DAX | Serverless scaling | Not supported by Portkey; wrong access pattern for KV cache |
+| CloudFront caching | Edge distribution | POST requests not cacheable by default; header-based cache keys are fragile for LLM payloads |
+| No cache | Zero complexity | Every request hits providers; highest cost and latency |
+
+## Consequences
+
+**Positive**:
+- Reduced provider costs for repeated or templated queries.
+- Lower latency for cache hits (sub-millisecond Redis vs. hundreds of milliseconds for provider round-trips).
+- Foundation for future semantic caching (similarity-based cache matching).
+
+**Negative**:
+- Additional infrastructure cost (~\$12/month for a single `cache.t4g.micro` node).
+- Cache invalidation complexity: stale responses are evicted only by LRU or TTL.
+- TLS overhead on every cache read/write (negligible in practice).
+
+## Future Enhancements
+
+- Semantic caching: match semantically similar prompts to cached responses using embedding similarity. Portkey supports this as an upgrade path.
+- Multi-node replication group with automatic failover for production workloads.
+- CloudWatch metrics for cache hit rate monitoring and alerting.

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -106,6 +106,10 @@ module "compute" {
   portkey_routing_configs = var.enable_provider_fallback ? {
     for name, config in var.routing_configs : name => base64encode(config)
   } : {}
+
+  # Cache
+  cache_enabled = var.enable_cache
+  redis_url     = var.enable_cache ? module.cache.redis_connection_url : ""
 }
 
 # -----------------------------------------------------------------------------
@@ -124,7 +128,6 @@ module "cost_attribution" {
   gateway_log_group_arn   = module.observability.gateway_log_group_arn
 }
 
-# -----------------------------------------------------------------------------
 # Guardrails (Bedrock content safety filtering)
 # -----------------------------------------------------------------------------
 
@@ -138,4 +141,20 @@ module "guardrails" {
   content_filter_strength = var.guardrails_content_filter_strength
   blocked_topics          = var.guardrails_blocked_topics
   blocked_words           = var.guardrails_blocked_words
+}
+
+# -----------------------------------------------------------------------------
+# Cache (ElastiCache Redis for response caching)
+# -----------------------------------------------------------------------------
+
+module "cache" {
+  source = "./modules/cache"
+
+  project_name = var.project_name
+  environment  = var.environment
+  enable_cache = var.enable_cache
+
+  private_subnet_ids    = module.networking.private_subnets
+  vpc_id                = module.networking.vpc_id
+  ecs_security_group_id = module.compute.ecs_security_group_id
 }

--- a/infrastructure/modules/cache/main.tf
+++ b/infrastructure/modules/cache/main.tf
@@ -1,0 +1,103 @@
+# =============================================================================
+# Cache — ElastiCache Redis for response caching
+# =============================================================================
+
+# ------------------------------------------------------------------
+# Parameter Group
+# ------------------------------------------------------------------
+
+resource "aws_elasticache_parameter_group" "redis" {
+  count = var.enable_cache ? 1 : 0
+
+  name   = "${var.project_name}-${var.environment}-redis7"
+  family = "redis7"
+
+  parameter {
+    name  = "maxmemory-policy"
+    value = "allkeys-lru"
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-redis7"
+  }
+}
+
+# ------------------------------------------------------------------
+# Subnet Group
+# ------------------------------------------------------------------
+
+resource "aws_elasticache_subnet_group" "redis" {
+  count = var.enable_cache ? 1 : 0
+
+  name       = "${var.project_name}-${var.environment}-redis"
+  subnet_ids = var.private_subnet_ids
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-redis"
+  }
+}
+
+# ------------------------------------------------------------------
+# Security Group
+# ------------------------------------------------------------------
+
+resource "aws_security_group" "redis" {
+  count = var.enable_cache ? 1 : 0
+
+  name        = "${var.project_name}-${var.environment}-redis"
+  description = "Security group for ElastiCache Redis"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-redis"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "redis_from_ecs" {
+  count = var.enable_cache ? 1 : 0
+
+  security_group_id            = aws_security_group.redis[0].id
+  description                  = "Redis from ECS tasks"
+  from_port                    = 6379
+  to_port                      = 6379
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = var.ecs_security_group_id
+}
+
+# ------------------------------------------------------------------
+# Replication Group (Redis)
+# ------------------------------------------------------------------
+
+resource "aws_elasticache_replication_group" "redis" {
+  count = var.enable_cache ? 1 : 0
+
+  replication_group_id = "${var.project_name}-${var.environment}"
+  description          = "Redis cache for ${var.project_name} response caching"
+
+  node_type            = var.cache_node_type
+  num_cache_clusters   = var.cache_num_nodes
+  engine_version       = var.cache_engine_version
+  port                 = 6379
+  parameter_group_name = aws_elasticache_parameter_group.redis[0].name
+  subnet_group_name    = aws_elasticache_subnet_group.redis[0].name
+  security_group_ids   = [aws_security_group.redis[0].id]
+
+  # Encryption
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+
+  # Single-node: no automatic failover
+  automatic_failover_enabled = var.cache_num_nodes > 1
+
+  # Maintenance & snapshots
+  maintenance_window       = "sun:05:00-sun:06:00"
+  snapshot_retention_limit = 1
+  snapshot_window          = "03:00-04:00"
+
+  # Apply changes immediately in dev; use maintenance window in prod
+  apply_immediately = true
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-redis"
+  }
+}

--- a/infrastructure/modules/cache/outputs.tf
+++ b/infrastructure/modules/cache/outputs.tf
@@ -1,0 +1,19 @@
+output "redis_endpoint" {
+  description = "Primary endpoint address of the Redis replication group"
+  value       = var.enable_cache ? aws_elasticache_replication_group.redis[0].primary_endpoint_address : ""
+}
+
+output "redis_port" {
+  description = "Port number of the Redis cluster"
+  value       = var.enable_cache ? 6379 : 0
+}
+
+output "redis_connection_url" {
+  description = "Full Redis connection URL with TLS (rediss://)"
+  value       = var.enable_cache ? "rediss://${aws_elasticache_replication_group.redis[0].primary_endpoint_address}:6379" : ""
+}
+
+output "redis_security_group_id" {
+  description = "Security group ID of the Redis cluster"
+  value       = var.enable_cache ? aws_security_group.redis[0].id : ""
+}

--- a/infrastructure/modules/cache/variables.tf
+++ b/infrastructure/modules/cache/variables.tf
@@ -1,0 +1,48 @@
+variable "project_name" {
+  description = "Project name used for resource naming"
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment (dev or prod)"
+  type        = string
+}
+
+variable "enable_cache" {
+  description = "Whether to create the ElastiCache Redis cluster"
+  type        = bool
+  default     = true
+}
+
+variable "private_subnet_ids" {
+  description = "List of private subnet IDs for the ElastiCache subnet group"
+  type        = list(string)
+}
+
+variable "vpc_id" {
+  description = "VPC ID for the Redis security group"
+  type        = string
+}
+
+variable "ecs_security_group_id" {
+  description = "Security group ID of the ECS service (to allow ingress from ECS to Redis)"
+  type        = string
+}
+
+variable "cache_node_type" {
+  description = "ElastiCache node instance type"
+  type        = string
+  default     = "cache.t4g.micro"
+}
+
+variable "cache_engine_version" {
+  description = "Redis engine version"
+  type        = string
+  default     = "7.1"
+}
+
+variable "cache_num_nodes" {
+  description = "Number of cache nodes in the replication group"
+  type        = number
+  default     = 1
+}

--- a/infrastructure/modules/compute/main.tf
+++ b/infrastructure/modules/compute/main.tf
@@ -330,7 +330,11 @@ module "ecs_service" {
         [for name, config in var.portkey_routing_configs : {
           name  = "PORTKEY_DEFAULT_CONFIG_${upper(name)}"
           value = config
-        }]
+        }],
+        var.cache_enabled ? [
+          { name = "CACHE_STORE", value = "redis" },
+          { name = "REDIS_URL", value = var.redis_url },
+        ] : []
       )
 
       secrets = [

--- a/infrastructure/modules/compute/outputs.tf
+++ b/infrastructure/modules/compute/outputs.tf
@@ -12,3 +12,8 @@ output "ecr_repository_url" {
   description = "URL of the ECR repository"
   value       = aws_ecr_repository.gateway.repository_url
 }
+
+output "ecs_security_group_id" {
+  description = "Security group ID of the ECS service"
+  value       = module.ecs_service.security_group_id
+}

--- a/infrastructure/modules/compute/variables.tf
+++ b/infrastructure/modules/compute/variables.tf
@@ -93,3 +93,15 @@ variable "portkey_routing_configs" {
   type        = map(string)
   default     = {}
 }
+
+variable "cache_enabled" {
+  description = "Whether response caching via Redis is enabled"
+  type        = bool
+  default     = false
+}
+
+variable "redis_url" {
+  description = "Redis connection URL (rediss:// for TLS). Required when cache_enabled is true."
+  type        = string
+  default     = ""
+}

--- a/infrastructure/variables_cache.tf
+++ b/infrastructure/variables_cache.tf
@@ -1,0 +1,15 @@
+# =============================================================================
+# Cache Variables
+# =============================================================================
+
+variable "enable_cache" {
+  description = "Whether to deploy an ElastiCache Redis cluster for response caching"
+  type        = bool
+  default     = false
+}
+
+variable "cache_node_type" {
+  description = "ElastiCache node instance type"
+  type        = string
+  default     = "cache.t4g.micro"
+}


### PR DESCRIPTION
## Summary
- New `infrastructure/modules/cache/` Terraform module for ElastiCache Redis
- Redis 7.1 with TLS in-transit + at-rest encryption, LRU eviction policy
- Security group rules: TCP 6379 ingress from ECS security group only
- Integrates with Portkey's built-in cache via `CACHE_STORE=redis` and `REDIS_URL` env vars
- Conditional creation (`enable_cache` toggle) — off by default
- ADR-012: Response Cache Strategy

## Files Changed
- `infrastructure/modules/cache/` — new module (main.tf, variables.tf, outputs.tf)
- `infrastructure/main.tf` — wires cache module to networking and compute
- `infrastructure/modules/compute/main.tf` — conditional CACHE_STORE + REDIS_URL env vars
- `infrastructure/modules/compute/variables.tf` — cache_enabled + redis_url variables
- `infrastructure/modules/compute/outputs.tf` — ecs_security_group_id output
- `infrastructure/variables_cache.tf` — enable_cache + cache_node_type
- `adr/012-response-cache-strategy.md` — architectural decision record

## Test plan
- [x] `terraform validate` passes
- [ ] `terraform plan` with `enable_cache = true` shows Redis cluster + env vars
- [ ] Verify Portkey cache-hit behavior with Redis connected