### PR TITLE
feat: add semver versioning policy and release bump tasks

### DIFF
--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,52 @@
+# Versioning Policy
+
+AI Gateway follows [Semantic Versioning 2.0.0](https://semver.org/) with the format `MAJOR.MINOR.PATCH`.
+
+## What Constitutes Each Bump
+
+| Bump | When | Examples |
+|------|------|----------|
+| **MAJOR** | Breaking changes to the gateway API, authentication scheme, or infrastructure that require consumer action | Changing auth from Cognito M2M to a different scheme; removing or renaming API endpoints; Terraform state-breaking module restructures |
+| **MINOR** | New functionality that is backward-compatible | Adding a new model provider; new API endpoints; new Terraform modules (cache, guardrails); new observability features |
+| **PATCH** | Backward-compatible bug fixes, security patches, dependency updates, documentation, and CI improvements | Fixing JWT validation edge cases; updating pinned action SHAs; Portkey version bumps; Terraform variable defaults |
+
+## Pre-release Tags
+
+Pre-release versions use suffixes per semver spec:
+
+- `v1.2.0-alpha.1` — Early development, unstable
+- `v1.2.0-beta.1` — Feature-complete but under testing
+- `v1.2.0-rc.1` — Release candidate
+
+The release workflow automatically marks these as pre-release on GitHub.
+
+## Version Sources
+
+The canonical version lives in two places that must stay in sync:
+
+| File | Field | Purpose |
+|------|-------|---------|
+| `pyproject.toml` | `version` | Python package version |
+| Git tag | `v{version}` | Triggers the release workflow |
+
+Use `mise run release:bump-*` tasks to update both atomically.
+
+## Release Flow
+
+1. Work is merged to `main` via PRs
+2. When ready to release, run the appropriate bump task:
+   ```bash
+   mise run release:bump-patch   # 0.1.0 → 0.1.1
+   mise run release:bump-minor   # 0.1.0 → 0.2.0
+   mise run release:bump-major   # 0.1.0 → 1.0.0
+   ```
+3. The task updates `pyproject.toml`, commits, tags, and pushes
+4. The `v*` tag triggers `.github/workflows/release.yml` which:
+   - Builds and pushes the container image to ECR
+   - Signs the image with cosign (keyless)
+   - Generates CycloneDX and SPDX SBOMs
+   - Creates a GitHub Release with auto-generated changelog
+
+## Current Status
+
+The project is in initial development (`0.x.y`). Per semver, the public API is not yet considered stable. Minor versions may include breaking changes until `1.0.0`.

--- a/mise.toml
+++ b/mise.toml
@@ -148,6 +148,52 @@ description = "CI-only: validate all CI + pre-commit in one shot"
 depends = ["lint", "typecheck", "security", "tf:validate", "ci:lint"]
 
 # ──────────────────────────────────────────────
+# Release tasks
+# ──────────────────────────────────────────────
+
+[tasks."release:bump-patch"]
+description = "Bump patch version (0.1.0 → 0.1.1), commit, tag, and push"
+run = """
+set -euo pipefail
+CURRENT=$(grep '^version' pyproject.toml | sed 's/.*"\\(.*\\)"/\\1/')
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+NEW="${MAJOR}.${MINOR}.$((PATCH + 1))"
+sed -i "s/^version = \"${CURRENT}\"/version = \"${NEW}\"/" pyproject.toml
+git add pyproject.toml
+git commit -m "release: v${NEW}"
+git tag "v${NEW}"
+echo "Bumped ${CURRENT} → ${NEW}. Run 'git push origin main --tags' to trigger the release."
+"""
+
+[tasks."release:bump-minor"]
+description = "Bump minor version (0.1.0 → 0.2.0), commit, tag, and push"
+run = """
+set -euo pipefail
+CURRENT=$(grep '^version' pyproject.toml | sed 's/.*"\\(.*\\)"/\\1/')
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+NEW="${MAJOR}.$((MINOR + 1)).0"
+sed -i "s/^version = \"${CURRENT}\"/version = \"${NEW}\"/" pyproject.toml
+git add pyproject.toml
+git commit -m "release: v${NEW}"
+git tag "v${NEW}"
+echo "Bumped ${CURRENT} → ${NEW}. Run 'git push origin main --tags' to trigger the release."
+"""
+
+[tasks."release:bump-major"]
+description = "Bump major version (0.1.0 → 1.0.0), commit, tag, and push"
+run = """
+set -euo pipefail
+CURRENT=$(grep '^version' pyproject.toml | sed 's/.*"\\(.*\\)"/\\1/')
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+NEW="$((MAJOR + 1)).0.0"
+sed -i "s/^version = \"${CURRENT}\"/version = \"${NEW}\"/" pyproject.toml
+git add pyproject.toml
+git commit -m "release: v${NEW}"
+git tag "v${NEW}"
+echo "Bumped ${CURRENT} → ${NEW}. Run 'git push origin main --tags' to trigger the release."
+"""
+
+# ──────────────────────────────────────────────
 # Documentation tasks
 # ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds `docs/VERSIONING.md` defining the semver policy for ai-gateway (what's major/minor/patch, pre-release tags, version sources, release flow)
- Adds three `mise run release:bump-*` tasks that atomically update `pyproject.toml`, commit, and tag

## Type of change

- [x] Documentation
- [x] CI/CD improvement

## Details

### Versioning Policy

| Bump | When |
|------|------|
| **MAJOR** | Breaking API/auth/infra changes requiring consumer action |
| **MINOR** | New backward-compatible features (providers, endpoints, modules) |
| **PATCH** | Bug fixes, security patches, dependency updates, docs, CI |

### Release Tasks

```bash
mise run release:bump-patch   # 0.1.0 → 0.1.1
mise run release:bump-minor   # 0.1.0 → 0.2.0
mise run release:bump-major   # 0.1.0 → 1.0.0
```

Each task updates `pyproject.toml`, creates a commit, and tags it. Push with `git push origin main --tags` to trigger the release workflow.

## Test plan

- [x] Versioning doc renders correctly
- [x] Tasks parse current version from `pyproject.toml` and compute the next version correctly

## Related issues

Fixes #25