### PR TITLE
chore: add OpenSSF Best Practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # AI Gateway
 
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/theagenticguy/ai-gateway/badge)](https://scorecard.dev/viewer/?uri=github.com/theagenticguy/ai-gateway)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12221/badge)](https://www.bestpractices.dev/en/projects/12221)
 [![CI/CD Pipeline](https://github.com/theagenticguy/ai-gateway/actions/workflows/ci.yml/badge.svg)](https://github.com/theagenticguy/ai-gateway/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/theagenticguy/ai-gateway/graph/badge.svg)](https://codecov.io/gh/theagenticguy/ai-gateway)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)


### PR DESCRIPTION
## Summary
- Adds the [OpenSSF Best Practices](https://www.bestpractices.dev/en/projects/12221) badge to the README badge row, alongside the existing Scorecard, CI/CD, Codecov, and License badges.

## Test plan
- [x] Badge URL resolves correctly: https://www.bestpractices.dev/projects/12221/badge
- [x] Link points to passing criteria page: https://www.bestpractices.dev/en/projects/12221