### PR TITLE
fix(docs): restore .mdx tables + correct stale claims and broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-AI Gateway is a lightweight LLM inference gateway on AWS that routes AI agent requests through [Portkey AI Gateway OSS](https://github.com/Portkey-ai/gateway) to multiple model providers -- Bedrock, OpenAI, Anthropic, Google, and Azure OpenAI -- via a unified API. It serves both the OpenAI Chat Completions format (`/v1/chat/completions`) and the Anthropic Messages format (`/v1/messages`) natively, so every major coding agent works out of the box.
+AI Gateway is a lightweight LLM inference gateway on AWS that routes AI agent requests through [Portkey AI Gateway OSS](https://github.com/Portkey-AI/gateway) to multiple model providers -- Bedrock, OpenAI, Anthropic, Google, and Azure OpenAI -- via a unified API. It serves both the OpenAI Chat Completions format (`/v1/chat/completions`) and the Anthropic Messages format (`/v1/messages`) natively, so every major coding agent works out of the box.
 
 Authentication uses Cognito M2M (`client_credentials`) with ALB-native JWT validation, eliminating the need for API Gateway and its per-request costs.
 
@@ -31,11 +31,11 @@ A detailed Mermaid architecture diagram is available in the `docs/` directory.
 |------|---------|---------|
 | [mise](https://mise.jdx.dev/) | latest | Tool version manager (installs all other tools) |
 | [uv](https://docs.astral.sh/uv/) | latest | Python package manager |
-| [Terraform](https://www.terraform.io/) | >= 1.9 | Infrastructure as code (installed via mise) |
+| [Terraform](https://www.terraform.io/) | ~> 1.14 | Infrastructure as code (installed via mise) |
 | [AWS CLI](https://aws.amazon.com/cli/) | v2 | AWS operations |
 | [Docker](https://www.docker.com/) | latest | Container builds and local testing |
 
-mise will install pinned versions of Python 3.13, Terraform 1.10.5, lefthook, checkov, trivy, hadolint, and gitleaks automatically from `mise.toml`.
+mise will install pinned versions of Python 3.13, Terraform 1.14.8, lefthook, checkov, trivy, hadolint, and gitleaks automatically from `mise.toml`.
 
 ## Quick Start
 
@@ -203,6 +203,13 @@ Architectural Decision Records are in the `adr/` directory.
 | [005](adr/005-alb-jwt-validation-over-api-gateway.md) | ALB JWT Validation Over API Gateway for Auth | Accepted |
 | [006](adr/006-portkey-dual-format-api.md) | Portkey OSS Natively Serves Both OpenAI and Anthropic API Formats | Accepted |
 | [007](adr/007-terraform-provider-upgrade-for-jwt.md) | Upgrade AWS Terraform Provider to >= 6.22 for ALB JWT Validation | Accepted |
+| [008](adr/008-multi-tenant-client-isolation.md) | Multi-Tenant Client Isolation via Per-Team Cognito App Clients | Accepted |
+| [009](adr/009-provider-routing-strategy.md) | Provider Routing Strategy | Accepted |
+| [010](adr/010-cost-attribution-pipeline.md) | Cost Attribution Pipeline via Lambda + CloudWatch Metrics | Accepted |
+| [011](adr/011-bedrock-guardrails-integration.md) | Bedrock Guardrails Integration for Content Safety Filtering | Accepted |
+| [012](adr/012-response-cache-strategy.md) | Response Cache Strategy with ElastiCache Redis | Accepted |
+| [013](adr/013-identity-center-saml-federation.md) | Identity Center SAML/OIDC Federation for User SSO | Accepted |
+| [014](adr/014-two-plane-architecture-split.md) | Two-Plane Architecture Split (ALB Inference + API Gateway Admin) | Accepted |
 
 ## Scripts
 
@@ -213,7 +220,7 @@ Architectural Decision Records are in the `adr/` directory.
 
 ## Agent Compatibility
 
-The gateway supports six AI coding agents across two API formats. See [docs/agent-setup.md](docs/agent-setup.md) for detailed configuration instructions.
+The gateway supports six AI coding agents across two API formats. See [docs/src/content/docs/user-guide/agent-setup.md](docs/src/content/docs/user-guide/agent-setup.md) for detailed configuration instructions.
 
 | Agent | API Format | Endpoint |
 |-------|-----------|----------|

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -4,6 +4,7 @@ import sitemap from "@astrojs/sitemap";
 import mermaid from "astro-mermaid";
 import starlightPageActions from "starlight-page-actions";
 import starlightLlmsTxt from "starlight-llms-txt";
+import remarkGfm from "remark-gfm";
 
 export default defineConfig({
   site: "https://theagenticguy.github.io",
@@ -91,7 +92,12 @@ export default defineConfig({
   ],
 
   markdown: {
-    remarkPlugins: [remarkStripMdLinks],
+    // remark-gfm is added explicitly: as of Astro 6.4 + @astrojs/mdx 5,
+    // supplying a custom remarkPlugins array no longer auto-injects the
+    // default GFM plugin into the MDX processor, so tables (and other GFM
+    // syntax) silently stopped rendering in .mdx pages. Listing it here
+    // restores GFM for both .md and .mdx.
+    remarkPlugins: [remarkGfm, remarkStripMdLinks],
   },
 });
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,6 +14,7 @@
     "astro": "^6.3.5",
     "astro-mermaid": "^2.0.1",
     "mermaid": "^11.15.0",
+    "remark-gfm": "^4.0.1",
     "starlight-llms-txt": "^0.10.0",
     "starlight-page-actions": "^0.6.0"
   },

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       mermaid:
         specifier: ^11.15.0
         version: 11.15.0
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       starlight-llms-txt:
         specifier: ^0.10.0
         version: 0.10.0(@astrojs/starlight@0.39.2(astro@6.4.2(@types/node@24.12.2)(rollup@4.60.2)))(astro@6.4.2(@types/node@24.12.2)(rollup@4.60.2))

--- a/docs/src/content/docs/admin-guide/deployment.md
+++ b/docs/src/content/docs/admin-guide/deployment.md
@@ -188,12 +188,14 @@ Terragrunt automatically:
 
 ## Updating the Gateway Image Version
 
-The Portkey gateway image version is controlled by the `portkey_image` variable. To update:
+The deployed image is a **custom hardened image built from pinned Portkey source** — not the upstream `portkeyai/gateway` image. The Portkey *version* is controlled by `versions.env` at the repo root (`PORTKEY_VERSION` + `PORTKEY_TARBALL_SHA256`), and the release workflow builds and pushes the image to ECR/GHCR. See [Upgrading](/ai-gateway/admin-guide/upgrading/) for the full version-bump flow.
 
-1. **Update the variable** in the appropriate tfvars or Terragrunt inputs:
+The `portkey_image` variable selects **which built image URI** ECS runs. Override it only when pinning to a specific published tag (for example, a rollback to a prior SHA); the normal upgrade path is to bump `versions.env` and let the workflow publish a new image.
+
+1. **Set the image URI** in the appropriate tfvars or Terragrunt inputs to a tag published by the release workflow:
 
     ```hcl
-    portkey_image = "portkeyai/gateway:1.16.0"
+    portkey_image = "ghcr.io/theagenticguy/ai-gateway:<tag>"
     ```
 
     Or for Terragrunt, update `_env/common.hcl`:
@@ -201,7 +203,7 @@ The Portkey gateway image version is controlled by the `portkey_image` variable.
     ```hcl
     locals {
       project_name  = "ai-gateway"
-      portkey_image = "portkeyai/gateway:1.16.0"
+      portkey_image = "ghcr.io/theagenticguy/ai-gateway:<tag>"
     }
     ```
 

--- a/docs/src/content/docs/developer-guide/ci-cd.md
+++ b/docs/src/content/docs/developer-guide/ci-cd.md
@@ -97,7 +97,8 @@ On pull requests, only the 4 gate jobs run. Build-and-push and deploy only execu
 |------|-------------|
 | Configure AWS credentials | OIDC-based assume-role (no long-lived keys) |
 | Login to ECR | Authenticate with Amazon ECR |
-| Pull + tag + push | Pull `portkeyai/gateway:1.15.2`, tag with SHA and `latest`, push to ECR |
+| Build custom image | Build the hardened image from the pinned Portkey source (`Dockerfile` with `PORTKEY_VERSION` / `PORTKEY_TARBALL_SHA256` build args from `versions.env`) |
+| Tag + push | Tag with the commit SHA and `latest`, push to ECR |
 | cosign sign | Keyless image signing via Sigstore OIDC |
 
 ### 6. Deploy to ECS

--- a/docs/src/content/docs/getting-started/prerequisites.mdx
+++ b/docs/src/content/docs/getting-started/prerequisites.mdx
@@ -17,7 +17,7 @@ Everything you need before deploying the AI Gateway.
 |---|---|---|
 | [mise](https://mise.jdx.dev/) | latest | Tool version manager -- installs all other tools automatically |
 | [uv](https://docs.astral.sh/uv/) | latest | Python package manager |
-| [Terraform](https://www.terraform.io/) | >= 1.9 | Infrastructure as code (installed via mise) |
+| [Terraform](https://www.terraform.io/) | ~> 1.14 | Infrastructure as code (installed via mise) |
 | [AWS CLI](https://aws.amazon.com/cli/) | v2 | AWS operations and credential management |
 | [Docker](https://www.docker.com/) | latest | Container builds and local testing |
 
@@ -25,7 +25,7 @@ Everything you need before deploying the AI Gateway.
 Running `mise install` in the project root automatically installs pinned versions of:
 
 - Python 3.13
-- Terraform 1.10.5
+- Terraform 1.14.8
 - Terragrunt (latest)
 - terraform-docs (latest)
 - lefthook 2.1.4

--- a/docs/src/content/docs/user-guide/routing-strategies.md
+++ b/docs/src/content/docs/user-guide/routing-strategies.md
@@ -4,7 +4,7 @@ description: "Provider routing strategies: fallback, load-balance, cost-optimize
 sidebar:
   order: 4
 ---
-The AI Gateway uses [Portkey's routing engine](https://portkey.ai/docs/product/ai-gateway/routing) to control how requests are distributed across LLM providers. This document covers the available strategies, pre-built config templates, and how to use them.
+The AI Gateway uses [Portkey's routing engine](https://portkey.ai/docs/product/ai-gateway) to control how requests are distributed across LLM providers. This document covers the available strategies, pre-built config templates, and how to use them.
 
 ## Available Strategies
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -4,14 +4,34 @@ Terraform root module for the AI Gateway — deploys VPC, ALB, ECS Fargate, Cogn
 
 ## Architecture
 
-This module is composed of 4 local sub-modules:
+This root module composes 17 local sub-modules. The core data plane is always deployed; the remaining modules are feature-gated by input variables (see the Inputs table below).
+
+**Core (always deployed):**
 
 | Module | Purpose |
 |--------|---------|
 | `modules/networking` | VPC, ALB, WAF, VPC endpoints |
 | `modules/auth` | Cognito User Pool, M2M client, ALB JWT validation |
 | `modules/compute` | ECS Fargate, ECR, IAM roles, Secrets Manager |
-| `modules/observability` | CloudWatch log groups, KMS encryption, dashboard |
+| `modules/observability` | KMS-encrypted CloudWatch log groups and dashboard |
+| `modules/cache` | ElastiCache Redis for response caching |
+| `modules/guardrails` | Bedrock Guardrails for content safety filtering |
+| `modules/content_scanner` | Lambda + Function URL for PII redaction and injection detection |
+| `modules/appconfig` | Feature flags and dynamic config for the content scanner |
+| `modules/cost_attribution` | Lambda pipeline attributing spend per team via CloudWatch metrics |
+| `modules/inspector` | Continuous ECR vulnerability scanning |
+
+**Optional (feature-gated):**
+
+| Module | Purpose | Enabled by |
+|--------|---------|-----------|
+| `modules/clients` | Per-team Cognito app clients for multi-tenant M2M access | `client_configs` non-empty |
+| `modules/admin_api` | API Gateway REST API admin plane with Cognito authorizer | `enable_admin_api` |
+| `modules/routing` | DynamoDB table for custom routing configs | `enable_admin_api` |
+| `modules/team_registration` | Self-service API for team onboarding | `enable_admin_api` |
+| `modules/budgets` | DynamoDB tables for budget definitions and usage tracking | `enable_budgets` |
+| `modules/chargeback` | Monthly chargeback report pipeline | `enable_chargeback` (+ `enable_budgets`) |
+| `modules/audit_log` | Kinesis Firehose → S3 (Parquet) with Glue Catalog | `enable_audit_log` |
 
 <!-- BEGIN_TF_DOCS -->
 


### PR DESCRIPTION
## Summary

Fixes a rendering regression on the docs home page and corrects stale claims / broken links found by a full cross-check of the README and docs against the codebase.

## The home page table bug

After the Astro 6.1 → 6.4 + `@astrojs/mdx` 5 upgrade (#149), tables on the home page (`index.mdx`) and other `.mdx` pages rendered as **literal pipe text** instead of HTML tables.

**Root cause:** the config supplies a custom `markdown.remarkPlugins` array (`remarkStripMdLinks`). As of Astro 6.4, doing so no longer auto-injects the default GFM remark plugin into the **MDX** processor, so GFM syntax (tables, strikethrough) silently stopped rendering in `.mdx` files. `.md` files kept working via a separate path — which is why only `.mdx` pages broke and it was easy to miss.

**Fix:** add `remark-gfm` as an explicit direct dependency and list it in `markdown.remarkPlugins`. Verified with `pnpm build`: home page now renders **2 tables (was 0)**, `user-guide/index.mdx` renders 1 (was 0), `.md` pages unchanged (14).

## Doc accuracy + link fixes

Two parallel audits (link-checker + code-vs-docs fact-checker) surfaced these, each verified against ground truth before editing:

| Fix | Detail |
|---|---|
| `infrastructure/README.md` | "4 local sub-modules" → documents all **17** modules (`main.tf` wires 17; the intro contradicted the terraform-docs block on the same page). Split into core vs feature-gated. |
| `README.md` ADR table | Listed only 001–007; added **008–014** (14 ADRs exist). |
| `README.md` broken link | `docs/agent-setup.md` → `docs/src/content/docs/user-guide/agent-setup.md`. |
| `README.md` + `prerequisites.mdx` | Terraform `>= 1.9` / `1.10.5` → `~> 1.14` / `1.14.8` (matches `versions.tf` + `mise.toml`; a 1.10.5 install fails `init`). |
| `README.md` | Portkey repo link casing `Portkey-ai` → `Portkey-AI`. |
| `developer-guide/ci-cd.md` | Release step said "Pull `portkeyai/gateway`"; pipeline actually **builds a custom hardened image from pinned source**. Corrected. |
| `admin-guide/deployment.md` | Image-version section pointed `portkey_image` at the raw upstream image (bypasses hardening). Rewrote to reference `versions.env` + the custom-built ECR/GHCR image. |
| `user-guide/routing-strategies.md` | Dead Portkey docs URL (404) → stable `/product/ai-gateway` page. |

## Audit false-positive (left unchanged, documented)

The link audit flagged 10 TOC anchors in `reference/infra-stack-research.md` as broken (`--` vs `----` slug mismatch). I verified against the **actual built HTML** — all 10 resolve correctly (Astro/Starlight's slugger collapses ` -- ` to `--`). The finding came from a manual github-slugger simulation that didn't match the real build. No change made.

## Validation

- `pnpm build`: ✅ 47 pages, clean
- Home/`.mdx` tables render; `.md` tables unchanged (regression-guarded)
- All README `adr/*` links + the fixed `agent-setup` link resolve on disk
- All edited claims verified against `main.tf`, `versions.tf`, `mise.toml`, `versions.env`, `Dockerfile`, release workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
