### PR TITLE
fix(docker): apply CVE patches silently dropped by COPY ordering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,32 +30,38 @@ RUN set -eu \
 # ── Stage 2: Build ───────────────────────────────────────────
 FROM node:${NODE_VERSION}-alpine@${NODE_ALPINE_DIGEST} AS build
 WORKDIR /app
-COPY --from=source /src/package*.json ./
-COPY --from=source /src/patches ./patches/
+# Copy the FULL upstream source first, THEN patch. Upstream ships its own
+# package.json + package-lock.json, so the patch and the regenerated lock must
+# be applied on top of the copied tree. The previous order patched first and
+# then ran `COPY /src .`, which silently clobbered both manifests with the
+# unpatched upstream ones before the final `npm ci` — so the CVE patches below
+# never actually shipped. Copy-then-patch fixes that.
+COPY --from=source /src .
 # Patch vulnerable deps at build time
 # Direct deps  → update version in dependencies (overrides can't touch direct deps)
-#   hono               4.12.11 ← CVE-2025-62610, CVE-2026-22817, CVE-2026-22818, CVE-2026-29045
-#   @hono/node-server  1.19.12 ← CVE-2026-29087 (HIGH)
+#   hono               4.12.23 ← CVE-2025-62610, CVE-2026-22817/22818/29045 + later 4.12.x GHSAs
+#   @hono/node-server  1.19.14 ← CVE-2026-29087 (HIGH) + GHSA-92pp-h63x-v22m (latest stable 1.x)
 # Transitive deps → npm overrides
 #   picomatch          2.3.2   ← CVE-2026-33671 (HIGH) + CVE-2026-33672 (MEDIUM)
 #   yaml               2.8.3   ← CVE-2026-33532 (MEDIUM)
 #   minimatch          9.0.9   ← CVE-2026-27904, CVE-2026-27903 (HIGH)
 #   brace-expansion    2.0.3   ← GHSA-f886-m6hf-6m8v (MEDIUM)
+#   tmp                0.2.6   ← CVE-2026-44705 (HIGH) path traversal
 RUN node -e " \
   const fs = require('fs'); \
   const pkg = JSON.parse(fs.readFileSync('package.json','utf8')); \
-  pkg.dependencies.hono = '4.12.11'; \
-  pkg.dependencies['@hono/node-server'] = '1.19.12'; \
+  pkg.dependencies.hono = '4.12.23'; \
+  pkg.dependencies['@hono/node-server'] = '1.19.14'; \
   pkg.overrides = { ...pkg.overrides, \
     picomatch: '2.3.2', \
     yaml: '2.8.3', \
     minimatch: '9.0.9', \
-    'brace-expansion': '2.0.3' \
+    'brace-expansion': '2.0.3', \
+    tmp: '0.2.6' \
   }; \
   fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));" \
     && npm install --package-lock-only --ignore-scripts \
     && npm ci
-COPY --from=source /src .
 RUN npm run build \
     && rm -rf node_modules \
     && npm ci --omit=dev


### PR DESCRIPTION
## Summary

**Security fix:** the Dockerfile's CVE patches have never actually shipped — in the current v1.15.2 production image included.

## Root cause

The build stage patched `package.json` (hono, picomatch, yaml, minimatch, brace-expansion), regenerated the lock, ran `npm ci`, and **then** ran `COPY --from=source /src .` immediately before the final `npm ci --omit=dev`. Upstream Portkey ships its own `package.json` **and** `package-lock.json`, so that `COPY` overwrote both patched manifests with the unpatched upstream ones. The final install resolved from the unpatched lock.

I proved it by building the current `v1.15.2` pin and inspecting the runtime image: `hono 4.9.7`, empty `overrides` — i.e. exactly upstream, none of the documented patches applied.

## Fix

Copy the full upstream source **first**, then patch on top, so the patched `package.json` + regenerated lock survive into the final `npm ci --omit=dev`. The `source` stage is keyed only on the build args, so layer caching is unaffected.

While correcting the patch set:
- `hono` 4.12.11 → **4.12.23**, `@hono/node-server` 1.19.12 → **1.19.14** (Grype flagged the old pins as superseded; staying on node-server 1.x to avoid the 2.x major).
- Added **`tmp` 0.2.6** override for CVE-2026-44705 (HIGH path traversal) — a pre-existing transitive exposure present in the v1.15.2 image.

This PR does **not** change `versions.env` — still building v1.15.2. (A follow-up PR proposes pinning a newer Portkey source ref.)

## Verification (local, on the v1.15.2 build)

| Check | Before | After |
|---|---|---|
| `hono` in runtime image | 4.9.7 (unpatched) | **4.12.23** |
| `@hono/node-server` | 1.3.x (unpatched) | **1.19.14** |
| picomatch / yaml / tmp | upstream | **2.3.2 / 2.8.3 / 0.2.6** |
| Trivy (HIGH/CRIT, `--ignore-unfixed --exit-code 1`) | — | ✅ exit 0 |
| Grype (`--fail-on critical`) | — | ✅ exit 0 |
| Container startup | — | ✅ `GET / → 200` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
