### PR TITLE
fix(security): patch ws@8.18.3 → 8.20.1 to remediate CVE-2026-45736

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ COPY --from=source /src .
 # Direct deps  → update version in dependencies (overrides can't touch direct deps)
 #   hono               4.12.23 ← CVE-2025-62610, CVE-2026-22817/22818/29045 + later 4.12.x GHSAs
 #   @hono/node-server  1.19.14 ← CVE-2026-29087 (HIGH) + GHSA-92pp-h63x-v22m (latest stable 1.x)
+#   ws                 8.20.1  ← CVE-2026-45736 (HIGH) uninitialized memory disclosure on close()
 # Transitive deps → npm overrides
 #   picomatch          2.3.2   ← CVE-2026-33671 (HIGH) + CVE-2026-33672 (MEDIUM)
 #   yaml               2.8.3   ← CVE-2026-33532 (MEDIUM)
@@ -64,6 +65,7 @@ RUN node -e " \
   const pkg = JSON.parse(fs.readFileSync('package.json','utf8')); \
   pkg.dependencies.hono = '4.12.23'; \
   pkg.dependencies['@hono/node-server'] = '1.19.14'; \
+  pkg.dependencies.ws = '8.20.1'; \
   pkg.overrides = { ...pkg.overrides, \
     picomatch: '2.3.2', \
     yaml: '2.8.3', \


### PR DESCRIPTION
## Summary

Patches `ws@8.18.3` to `8.20.1` at Docker build time, following the same pattern already used for `hono` and `@hono/node-server`.

After PR #154 (Alpine 3.23.4 base bump) cleared all OS-package CVEs, the nightly rescan still failed Trivy with **one** finding in Portkey's bundled `node_modules`:

| CVE | Package | Severity | Fixed | Reachability |
|---|---|---|---|---|
| [CVE-2026-45736](https://avd.aquasec.com/nvd/cve-2026-45736) | `ws` 8.18.3 | HIGH (GitHub security-severity) | 8.20.1 | The Portkey gateway terminates WebSocket connections; `WebSocket.close()` is on the request path. |

`WebSocket.close()` is vulnerable to uninitialized-memory disclosure when a `TypedArray` is passed as the close reason. Fixed in 8.20.1.

Portkey HEAD (`669825c`, May 25) still pins `ws@^8.18.0` — no upstream fix. We patch at our build layer rather than ignore.

## Why `dependencies` rather than `overrides`

`ws` is a **direct** dep in Portkey's `package.json`. npm rejects `overrides` against direct deps with `EOVERRIDE`, so the patch must go in `pkg.dependencies` (matching how `hono` and `@hono/node-server` are pinned).

## Validation

Built locally with the workflow's exact build-args, then ran the workflow's exact gate:

```
docker build \
  --build-arg PORTKEY_REF=669825cbe89ee51569918b8f78a9db486fd69dd4 \
  --build-arg PORTKEY_VERSION=1.15.2+669825c \
  --build-arg PORTKEY_TARBALL_SHA256=d69ce5369b2a9fd61beb44608c9f09458fbd2bf3bd5ef884348c19a17b26b8c1 \
  -t ai-gateway:rescan-test .

trivy image --severity CRITICAL,HIGH --ignore-unfixed --exit-code 1 ai-gateway:rescan-test
# → exit 0  (was exit 1 with CVE-2026-45736 before the patch)
```

## Failing run that surfaced this

https://github.com/theagenticguy/ai-gateway/actions/runs/26733858008 (post-#154; only finding remaining was CVE-2026-45736).

## Test plan

- [ ] CI green on this PR
- [ ] After merge: `gh workflow run rescan-on-advisory.yml --ref main` passes