### PR TITLE
fix(deps): sync uv.lock for boto3 >=1.43.27

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -30,7 +30,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = ">=1.43.24" },
+    { name = "boto3", specifier = ">=1.43.27" },
     { name = "email-validator", specifier = ">=2.3.0" },
     { name = "pydantic", specifier = ">=2.13.4" },
 ]


### PR DESCRIPTION
Lockfile sync after #177 (boto3 floor >=1.43.24 → >=1.43.27). Dependabot's pip updater bumps `pyproject.toml` floors but doesn't regenerate `uv.lock`, and CI runs `uv sync --frozen`, so the lock must track. `uv lock --locked` passes clean. Pure metadata.

🤖 Bonk nightly maintenance follow-up.