### PR TITLE
fix(security): patch ws/tmp HIGH CVEs in Portkey build + guard scanner against tag downgrades

### DIFF
--- a/.github/workflows/portkey-release-scanner.yml
+++ b/.github/workflows/portkey-release-scanner.yml
@@ -55,13 +55,25 @@ jobs:
             exit 0
           fi
 
-          # If the latest release tag is not what we're pinned to, prefer it.
+          # Prefer a release tag ONLY when it is genuinely ahead of our pin.
+          # We deliberately track a commit SHA on main that sits AHEAD of the
+          # latest tag (post-v1.15.2 security fixes), so a tag that differs from
+          # our pin is usually a DOWNGRADE, not an upgrade. The compare API tells
+          # us the direction: base=our pin, head=tag.
+          #   status "ahead"/"diverged" → tag has commits we lack → real upgrade
+          #   status "behind"/"identical" → our pin already contains the tag → skip
+          # This is the fix for the recurring false-positive downgrade PR (#193).
           if [[ -n "$LATEST_TAG" && "$LATEST_TAG" != "$PORTKEY_REF" && "v${PORTKEY_REF}" != "$LATEST_TAG" ]]; then
-            echo "Latest release tag: ${LATEST_TAG}, current pin: ${PORTKEY_REF}"
-            echo "new_ref=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
-            echo "new_version=${LATEST_TAG#v}" >> "$GITHUB_OUTPUT"
-            echo "::notice::Newer Portkey release tag found: ${LATEST_TAG}"
-            exit 0
+            CMP_STATUS=$(gh api "repos/Portkey-AI/gateway/compare/${PORTKEY_REF}...${LATEST_TAG}" --jq '.status' 2>/dev/null || true)
+            echo "Latest release tag: ${LATEST_TAG}, current pin: ${PORTKEY_REF}, compare status: ${CMP_STATUS:-unknown}"
+            if [[ "$CMP_STATUS" == "ahead" || "$CMP_STATUS" == "diverged" ]]; then
+              echo "new_ref=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
+              echo "new_version=${LATEST_TAG#v}" >> "$GITHUB_OUTPUT"
+              echo "::notice::Newer Portkey release tag found (${CMP_STATUS}): ${LATEST_TAG}"
+              exit 0
+            fi
+            # behind / identical / unknown → our SHA pin already includes the tag.
+            echo "::notice::Release tag ${LATEST_TAG} is not ahead of our pin (status: ${CMP_STATUS:-unknown}) — skipping tag downgrade, checking main."
           fi
 
           # No newer tag — compare main HEAD against our pinned SHA.

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,23 +53,29 @@ COPY --from=source /src .
 # Direct deps  → update version in dependencies (overrides can't touch direct deps)
 #   hono               4.12.23 ← CVE-2025-62610, CVE-2026-22817/22818/29045 + later 4.12.x GHSAs
 #   @hono/node-server  1.19.14 ← CVE-2026-29087 (HIGH) + GHSA-92pp-h63x-v22m (latest stable 1.x)
+#   ws                 8.21.0  ← CVE-2026-48779 (HIGH) + CVE-2026-45736 (MEDIUM); upstream
+#                                pins ^8.18.0 (resolves 8.18.3). Also overridden below so the
+#                                @hono/node-ws@1.2.0 transitive copy (ws ^8.17.0) is forced too.
 # Transitive deps → npm overrides
 #   picomatch          2.3.2   ← CVE-2026-33671 (HIGH) + CVE-2026-33672 (MEDIUM)
 #   yaml               2.8.3   ← CVE-2026-33532 (MEDIUM)
 #   minimatch          9.0.9   ← CVE-2026-27904, CVE-2026-27903 (HIGH)
 #   brace-expansion    2.0.3   ← GHSA-f886-m6hf-6m8v (MEDIUM)
-#   tmp                0.2.6   ← CVE-2026-44705 (HIGH) path traversal
+#   tmp                0.2.7   ← CVE-2026-49982 (HIGH) + CVE-2026-44705 (HIGH) path traversal
+#   ws                 8.21.0  ← forces the @hono/node-ws transitive copy (see direct dep above)
 RUN node -e " \
   const fs = require('fs'); \
   const pkg = JSON.parse(fs.readFileSync('package.json','utf8')); \
   pkg.dependencies.hono = '4.12.23'; \
   pkg.dependencies['@hono/node-server'] = '1.19.14'; \
+  pkg.dependencies.ws = '8.21.0'; \
   pkg.overrides = { ...pkg.overrides, \
     picomatch: '2.3.2', \
     yaml: '2.8.3', \
     minimatch: '9.0.9', \
     'brace-expansion': '2.0.3', \
-    tmp: '0.2.6' \
+    tmp: '0.2.7', \
+    ws: '8.21.0' \
   }; \
   fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));" \
     && npm install --package-lock-only --ignore-scripts \


### PR DESCRIPTION
## Summary

Two fixes that together stop the recurring nightly false positives on our Portkey pin:

1. **Clear the two real HIGH transitive CVEs** in the deployed image (the genuine findings behind issue #192).
2. **Teach the release-scanner not to propose tag downgrades** (the false-positive that produced #193).

## 1. Dockerfile — ws + tmp CVE patches

The nightly Trivy image rescan flags three findings in the **current pinned build** (`669825c`), and they are real (not version-label noise):

| Package | Was | Now | CVE | Sev |
|---|---|---|---|---|
| `ws` | 8.18.3 | **8.21.0** | CVE-2026-48779 | HIGH |
| `ws` | 8.18.3 | **8.21.0** | CVE-2026-45736 | MED |
| `tmp` | 0.2.6 | **0.2.7** | CVE-2026-49982 | HIGH |

Details:
- **`ws` is a direct dependency** upstream (`^8.18.0` → resolves 8.18.3). Per this Dockerfile's own convention (overrides can't cleanly touch direct deps), bumped in `dependencies` to `8.21.0`, **and** added as an override so the transitive `@hono/node-ws@1.2.0` copy (`ws ^8.17.0`) is forced to the same version. `8.21.0` satisfies both ranges.
- **`tmp` was already overridden to `0.2.6`** (for an older CVE) — which is exactly the version now flagged. So this is a **bump of the existing override** `0.2.6 → 0.2.7`, not a new entry. Left as a transitive override (upstream resolves `tmp` only transitively).

**Verification** (no Docker needed — replayed the exact build-stage patch + `npm install --package-lock-only`, the same command the Dockerfile runs):
- regenerated lockfile resolves `ws=8.21.0`, `tmp=0.2.7`, single `ws` instance (override collapsed the hono copy)
- `npm audit --audit-level=high --omit=dev` → **found 0 vulnerabilities**
- no new HIGH/CRITICAL introduced by the bumps

## 2. portkey-release-scanner.yml — downgrade guard

We deliberately pin a **commit SHA ahead of the latest release tag** (`669825c` = `1.15.2+669825c`, carrying post-v1.15.2 security fixes: public-route auth, admin-token hardening, log redaction, header-loop fix). The scanner's tag-preference branch fired whenever `latest_tag != pin`, ignoring **direction** — so it kept opening downgrade PRs (e.g. #193) proposing `v1.15.2`, which would revert those fixes.

Fix: gate the tag proposal on the GitHub **compare API** (`base=pin`, `head=tag`):
- `ahead` / `diverged` → tag has commits we lack → real upgrade, propose it
- `behind` / `identical` / unknown → our pin already contains the tag → skip, fall through to the main-HEAD check

Confirmed against live upstream: `compare/669825c...v1.15.2` → `status: behind, behind_by: 25`. The main-HEAD path is unchanged and still tracks `main` when it advances (today `main` == our pin, so the scanner correctly proposes nothing).

## Risk
- `ws` 8.18→8.21 and `tmp` 0.2.6→0.2.7 are patch/minor within the same major — no breaking API changes.
- Scanner change is logic-only (adds a direction check); the SHA-tracking fallback is untouched.

Refs #192 · supersedes the closed downgrade #193.