### PR TITLE
fix(security): bump hono 4.12.23 → 4.12.26 to clear new HIGH CVE cluster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,10 @@ WORKDIR /app
 COPY --from=source /src .
 # Patch vulnerable deps at build time
 # Direct deps  → update version in dependencies (overrides can't touch direct deps)
-#   hono               4.12.23 ← CVE-2025-62610, CVE-2026-22817/22818/29045 + later 4.12.x GHSAs
+#   hono               4.12.26 ← CVE-2026-54290 (HIGH, CORS credential reflection) +
+#                                CVE-2026-54286/54287/54288/54289 (MED); fixed in 4.12.25,
+#                                4.12.26 is latest 4.12.x stable. Supersedes the earlier
+#                                4.12.23 pin (CVE-2025-62610, CVE-2026-22817/22818/29045).
 #   @hono/node-server  1.19.14 ← CVE-2026-29087 (HIGH) + GHSA-92pp-h63x-v22m (latest stable 1.x)
 #   ws                 8.21.0  ← CVE-2026-48779 (HIGH) + CVE-2026-45736 (MEDIUM); upstream
 #                                pins ^8.18.0 (resolves 8.18.3). Also overridden below so the
@@ -66,7 +69,7 @@ COPY --from=source /src .
 RUN node -e " \
   const fs = require('fs'); \
   const pkg = JSON.parse(fs.readFileSync('package.json','utf8')); \
-  pkg.dependencies.hono = '4.12.23'; \
+  pkg.dependencies.hono = '4.12.26'; \
   pkg.dependencies['@hono/node-server'] = '1.19.14'; \
   pkg.dependencies.ws = '8.21.0'; \
   pkg.overrides = { ...pkg.overrides, \


### PR DESCRIPTION
## Summary

The nightly **Rescan on Advisory** Trivy image scan has failed every night since 2026-06-18, opening automated issue #203. Root cause: a new **hono** CVE cluster disclosed 06-18 that the current pinned build (`669825c`) is exposed to. This bumps the existing build-time hono pin to clear it.

This is **not** a new patch mechanism — the Dockerfile already pins/overrides vulnerable Portkey deps (from #202). The `ws@8.21.0` and `tmp@0.2.7` patches there are still effective; their alerts (#406/#407) already cleared. Only `hono` regressed, because 4.12.23 predates these advisories.

## Findings cleared

| CVE | Severity | Fixed in | Issue |
|---|---|---|---|
| CVE-2026-54290 | **HIGH** | 4.12.25 | CORS middleware reflects any Origin with credentials when `origin` defaults to wildcard |
| CVE-2026-54286 | MEDIUM | 4.12.25 | |
| CVE-2026-54287 | MEDIUM | 4.12.25 | |
| CVE-2026-54288 | MEDIUM | 4.12.25 | |
| CVE-2026-54289 | MEDIUM | 4.12.25 | |

## Change

`hono` is a direct dependency upstream, so per this Dockerfile's convention (overrides can't touch direct deps) the fix bumps the pin in `pkg.dependencies`:

```diff
-  pkg.dependencies.hono = '4.12.23';
+  pkg.dependencies.hono = '4.12.26';
```

4.12.25 is the minimum fixed version; 4.12.26 (2026-06-18) is the latest 4.12.x stable.

## Verification (local, CI-gate parity)

```
docker build -t ai-gateway:hono-fix .
trivy image --scanners vuln --severity CRITICAL,HIGH --ignore-unfixed --exit-code 1 ai-gateway:hono-fix
→ exit 0   (0 HIGH/CRITICAL findings)
```

Installed versions in the built image: `hono 4.12.26`, `ws 8.21.0`, `tmp 0.2.7`, `@hono/node-server 1.19.14`. The 5 hono CVEs (54286–54290) are absent from the scan output.

Closes #203.