### PR TITLE
refactor: migrate usage_api + pricing_admin + routing_config onto gwcore

### DIFF
--- a/src/pricing_admin/handler.py
+++ b/src/pricing_admin/handler.py
@@ -13,7 +13,6 @@ Routes:
 
 from __future__ import annotations
 
-import contextlib
 import os
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -270,9 +269,10 @@ def handler(event: dict[str, Any], _context: Any = None) -> dict[str, Any]:  # n
     except errors.ControlPlaneError as exc:
         if exc.status in {401, 403}:
             emit_metric("AuthzDenied", 1, dimensions={"Route": "pricing_admin"})
-            actor = "unknown"
-            with contextlib.suppress(errors.ControlPlaneError):
+            try:
                 actor = auth.build_principal(event).sub or "unknown"
+            except errors.ControlPlaneError:
+                actor = "unknown"
             audit.emit(
                 audit.event_from_request(
                     event,

--- a/src/pricing_admin/handler.py
+++ b/src/pricing_admin/handler.py
@@ -1,14 +1,19 @@
-"""Pricing admin Lambda (Function URL).
+"""Pricing admin Lambda — dynamic pricing overrides, migrated onto gwcore (ADR-016).
 
-Manages dynamic pricing overrides stored in DynamoDB.
-Static pricing from cost_attribution.pricing serves as the fallback
-when no DynamoDB entry exists for a given provider/model pair.
+DynamoDB overrides take priority over the static ``cost_attribution.pricing``
+table. Authorization is now enforced in-handler (it was not): every request
+requires the admin scope, and the upsert / delete mutations emit audit events.
+
+Routes:
+    GET    /pricing                      -- list all prices (DDB + static merged)
+    GET    /pricing/{provider}/{model}   -- get a specific price
+    PUT    /pricing/{provider}/{model}   -- upsert a pricing entry
+    DELETE /pricing/{provider}/{model}   -- delete a pricing override
 """
 
 from __future__ import annotations
 
-import json
-import logging
+import contextlib
 import os
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -19,28 +24,15 @@ from botocore.exceptions import ClientError
 from pydantic import ValidationError
 
 from cost_attribution.pricing import PRICING_TABLE
+from gwcore import audit, auth, errors, ok, responses
+from gwcore.logging import bind, correlation_id, get_logger
+from gwcore.responses import request_body
+from gwcore.telemetry import Timer, emit_metric
 from pricing_admin.models import PriceEntry, PriceSummary
 
-logger = logging.getLogger("pricing_admin")
-logger.setLevel(logging.INFO)
-if not logger.handlers:
-    _h = logging.StreamHandler()
-    _h.setFormatter(
-        logging.Formatter(
-            json.dumps(
-                {
-                    "timestamp": "%(asctime)s",
-                    "level": "%(levelname)s",
-                    "logger": "%(name)s",
-                    "message": "%(message)s",
-                }
-            )
-        )
-    )
-    logger.addHandler(_h)
+logger = get_logger("pricing_admin")
 
 PRICING_TABLE_NAME = os.environ.get("PRICING_TABLE_NAME", "gateway-pricing")
-
 dynamodb = boto3.resource("dynamodb", region_name=os.environ.get("AWS_REGION", "us-east-1"))
 
 # Minimum path parts for provider/model extraction: /pricing/{provider}/{model} → 3
@@ -51,31 +43,22 @@ _MIN_PATH_PARTS_WITH_PROVIDER_MODEL = 3
 
 
 def _make_pk(provider: str, model: str) -> str:
-    """Build the partition key for a pricing entry."""
     return f"PRICE#{provider}#{model}"
 
 
 def _get_price_item(provider: str, model: str) -> dict[str, Any] | None:
-    """Fetch a single pricing entry from DynamoDB."""
     table = dynamodb.Table(PRICING_TABLE_NAME)
-    resp = table.get_item(Key={"PK": _make_pk(provider, model), "SK": "CONFIG"})
-    return resp.get("Item")
+    return table.get_item(Key={"PK": _make_pk(provider, model), "SK": "CONFIG"}).get("Item")
 
 
 def _list_price_items() -> list[dict[str, Any]]:
-    """List all pricing entries from DynamoDB."""
     table = dynamodb.Table(PRICING_TABLE_NAME)
-    resp = table.scan(
-        FilterExpression="SK = :sk",
-        ExpressionAttributeValues={":sk": "CONFIG"},
-    )
+    resp = table.scan(FilterExpression="SK = :sk", ExpressionAttributeValues={":sk": "CONFIG"})
     return resp.get("Items", [])
 
 
 def _put_price_item(entry: PriceEntry) -> None:
-    """Store a pricing entry in DynamoDB."""
     table = dynamodb.Table(PRICING_TABLE_NAME)
-    now = datetime.now(tz=UTC).isoformat()
     item: dict[str, Any] = {
         "PK": _make_pk(entry.provider, entry.model),
         "SK": "CONFIG",
@@ -83,7 +66,7 @@ def _put_price_item(entry: PriceEntry) -> None:
         "model": entry.model,
         "input_per_1k": Decimal(str(entry.input_per_1k)),
         "output_per_1k": Decimal(str(entry.output_per_1k)),
-        "updated_at": now,
+        "updated_at": datetime.now(tz=UTC).isoformat(),
     }
     if entry.cache_read_per_1k is not None:
         item["cache_read_per_1k"] = Decimal(str(entry.cache_read_per_1k))
@@ -93,7 +76,7 @@ def _put_price_item(entry: PriceEntry) -> None:
 
 
 def _delete_price_item(provider: str, model: str) -> bool:
-    """Delete a pricing entry from DynamoDB. Returns True if it existed."""
+    """Delete a pricing entry. Returns True if it existed."""
     table = dynamodb.Table(PRICING_TABLE_NAME)
     try:
         table.delete_item(
@@ -101,62 +84,44 @@ def _delete_price_item(provider: str, model: str) -> bool:
             ConditionExpression="attribute_exists(PK)",
         )
     except ClientError as e:
-        error_code = e.response.get("Error", {}).get("Code", "")
-        if error_code == "ConditionalCheckFailedException":
+        if e.response.get("Error", {}).get("Code", "") == "ConditionalCheckFailedException":
             return False
         raise
-    else:
-        return True
+    return True
 
 
-# -- Route handling ------------------------------------------------------------
+# -- Route helpers -------------------------------------------------------------
 
 
-def _extract_path_and_method(event: dict[str, Any]) -> tuple[str, str]:
-    """Extract HTTP method and path from a Lambda Function URL event."""
-    request_context = event.get("requestContext", {})
-    http = request_context.get("http", {})
-    method = http.get("method", "GET").upper()
-    raw_path = http.get("path", event.get("rawPath", "/"))
-    return raw_path, method
+def _path_method(event: dict[str, Any]) -> tuple[str, str]:
+    http = event.get("requestContext", {}).get("http", {})
+    method = event.get("httpMethod") or http.get("method", "GET")
+    path = http.get("path") or event.get("path") or event.get("rawPath", "/")
+    return str(path), str(method).upper()
 
 
-def _parse_body(event: dict[str, Any]) -> dict[str, Any]:
-    """Parse JSON body from Lambda Function URL event."""
-    body_str = event.get("body", "{}")
-    if event.get("isBase64Encoded"):
-        import base64  # noqa: PLC0415
-
-        body_str = base64.b64decode(body_str).decode()
-    return json.loads(body_str) if isinstance(body_str, str) else body_str
-
-
-def _extract_provider_model(path: str) -> tuple[str | None, str | None]:
-    """Extract provider and model from path (e.g. /pricing/{provider}/{model}).
-
-    Returns (provider, model) or (None, None) if path doesn't contain both.
-    """
+def _provider_model(path: str) -> tuple[str | None, str | None]:
     parts = [p for p in path.strip("/").split("/") if p]
     if len(parts) >= _MIN_PATH_PARTS_WITH_PROVIDER_MODEL and parts[0] == "pricing":
         return parts[1], parts[2]
     return None, None
 
 
-def _handle_list_prices() -> dict[str, Any]:
-    """GET /pricing -- list all prices (DynamoDB + static merged)."""
+def _audit(event: dict[str, Any], principal: auth.Principal, **kw: Any) -> None:
+    audit.emit(audit.event_from_request(event, actor=principal.sub, team=principal.team, **kw))
+
+
+# -- Route handlers ------------------------------------------------------------
+
+
+def _list_prices() -> dict[str, Any]:
+    """GET /pricing — list DynamoDB overrides merged with static fallbacks."""
     summaries: list[dict[str, Any]] = []
-
-    # Start with static entries
     seen: set[tuple[str, str]] = set()
-
-    # Load DynamoDB entries first (they take priority)
     try:
-        ddb_items = _list_price_items()
-        for item in ddb_items:
-            provider = item.get("provider", "")
-            model = item.get("model", "")
-            key = (provider, model)
-            seen.add(key)
+        for item in _list_price_items():
+            provider, model = item.get("provider", ""), item.get("model", "")
+            seen.add((provider, model))
             summaries.append(
                 PriceSummary(
                     provider=provider,
@@ -166,13 +131,11 @@ def _handle_list_prices() -> dict[str, Any]:
                     source="dynamodb",
                 ).model_dump()
             )
-    except Exception:
+    except ClientError:
         logger.exception("Failed to list pricing entries from DynamoDB")
 
-    # Add static entries that aren't overridden
     for (provider, model), token_price in sorted(PRICING_TABLE.items()):
-        key = (provider, model)
-        if key not in seen:
+        if (provider, model) not in seen:
             summaries.append(
                 PriceSummary(
                     provider=provider,
@@ -182,41 +145,30 @@ def _handle_list_prices() -> dict[str, Any]:
                     source="static",
                 ).model_dump()
             )
+    return ok({"prices": summaries, "total": len(summaries)})
 
-    return _build_response(200, {"prices": summaries, "total": len(summaries)})
 
-
-def _handle_get_price(provider: str, model: str) -> dict[str, Any]:
-    """GET /pricing/{provider}/{model} -- get a specific price."""
-    # Check DynamoDB first
+def _get_price(provider: str, model: str) -> dict[str, Any]:
+    """GET /pricing/{provider}/{model} — DynamoDB override then static fallback."""
     try:
         item = _get_price_item(provider, model)
-        if item:
-            entry = PriceEntry(
-                provider=item.get("provider", provider),
-                model=item.get("model", model),
-                input_per_1k=float(item.get("input_per_1k", 0)),
-                output_per_1k=float(item.get("output_per_1k", 0)),
-                cache_read_per_1k=(
-                    float(item["cache_read_per_1k"]) if item.get("cache_read_per_1k") is not None else None
-                ),
-                cache_write_per_1k=(
-                    float(item["cache_write_per_1k"]) if item.get("cache_write_per_1k") is not None else None
-                ),
-                updated_at=item.get("updated_at", ""),
-            )
-            return _build_response(
-                200,
-                {
-                    "source": "dynamodb",
-                    "price": entry.model_dump(),
-                },
-            )
-    except Exception:
-        logger.exception("Failed to fetch price from DynamoDB: %s/%s", provider, model)
-        return _build_response(500, {"error": "Failed to fetch price from storage"})
+    except ClientError as e:
+        raise errors.UpstreamError("Failed to fetch price from storage") from e
 
-    # Fall back to static table
+    if item:
+        entry = PriceEntry(
+            provider=item.get("provider", provider),
+            model=item.get("model", model),
+            input_per_1k=float(item.get("input_per_1k", 0)),
+            output_per_1k=float(item.get("output_per_1k", 0)),
+            cache_read_per_1k=(float(item["cache_read_per_1k"]) if item.get("cache_read_per_1k") is not None else None),
+            cache_write_per_1k=(
+                float(item["cache_write_per_1k"]) if item.get("cache_write_per_1k") is not None else None
+            ),
+            updated_at=item.get("updated_at", ""),
+        )
+        return ok({"source": "dynamodb", "price": entry.model_dump()})
+
     static_price = PRICING_TABLE.get((provider, model))
     if static_price:
         entry = PriceEntry(
@@ -227,112 +179,113 @@ def _handle_get_price(provider: str, model: str) -> dict[str, Any]:
             cache_read_per_1k=static_price.cache_read_per_1k,
             cache_write_per_1k=static_price.cache_write_per_1k,
         )
-        return _build_response(
-            200,
-            {
-                "source": "static",
-                "price": entry.model_dump(),
-            },
-        )
+        return ok({"source": "static", "price": entry.model_dump()})
 
-    return _build_response(404, {"error": f"Price not found: {provider}/{model}"})
+    raise errors.NotFoundError(f"Price not found: {provider}/{model}")
 
 
-def _handle_upsert_price(provider: str, model: str, event: dict[str, Any]) -> dict[str, Any]:
-    """PUT /pricing/{provider}/{model} -- upsert a pricing entry."""
+def _upsert_price(provider: str, model: str, event: dict[str, Any], principal: auth.Principal) -> dict[str, Any]:
+    """PUT /pricing/{provider}/{model} — upsert a pricing override."""
+    import json  # noqa: PLC0415 — local parse to inject path params before validation
+
     try:
-        body = _parse_body(event)
-    except Exception:
-        return _build_response(400, {"error": "Invalid JSON body"})
-
+        body = json.loads(request_body(event))
+    except (json.JSONDecodeError, ValueError) as e:
+        raise errors.ValidationFailedError("Invalid JSON body") from e
     if not isinstance(body, dict):
-        return _build_response(400, {"error": "Request body must be a JSON object"})
+        raise errors.ValidationFailedError("Request body must be a JSON object")
 
-    # Inject provider and model from path
+    # provider/model come from the path, not the body.
     body["provider"] = provider
     body["model"] = model
-
     try:
         entry = PriceEntry.model_validate(body)
     except ValidationError as e:
-        return _build_response(400, {"error": f"Validation failed: {e.error_count()} errors", "details": e.errors()})
+        raise errors.ValidationFailedError("Invalid pricing entry", details={"errors": e.errors()}) from e
 
     try:
         _put_price_item(entry)
-    except Exception:
-        logger.exception("Failed to store price: %s/%s", provider, model)
-        return _build_response(500, {"error": "Failed to store price"})
+    except ClientError as e:
+        raise errors.UpstreamError("Failed to store price") from e
 
     logger.info("Upserted pricing entry: %s/%s", provider, model)
-    return _build_response(
-        200,
-        {
-            "message": f"Price upserted: {provider}/{model}",
-            "price": entry.model_dump(),
-        },
+    _audit(
+        event,
+        principal,
+        action="pricing.upsert",
+        resource=f"{provider}/{model}",
+        after={"input_per_1k": entry.input_per_1k, "output_per_1k": entry.output_per_1k},
     )
+    return ok({"message": f"Price upserted: {provider}/{model}", "price": entry.model_dump()})
 
 
-def _handle_delete_price(provider: str, model: str) -> dict[str, Any]:
-    """DELETE /pricing/{provider}/{model} -- delete a pricing override."""
+def _delete_price(provider: str, model: str, event: dict[str, Any], principal: auth.Principal) -> dict[str, Any]:
+    """DELETE /pricing/{provider}/{model} — delete a pricing override."""
     try:
         deleted = _delete_price_item(provider, model)
-    except Exception:
-        logger.exception("Failed to delete price: %s/%s", provider, model)
-        return _build_response(500, {"error": "Failed to delete price"})
-
+    except ClientError as e:
+        raise errors.UpstreamError("Failed to delete price") from e
     if not deleted:
-        return _build_response(404, {"error": f"Price override not found: {provider}/{model}"})
+        raise errors.NotFoundError(f"Price override not found: {provider}/{model}")
 
-    # Check if a static fallback exists
     has_static = (provider, model) in PRICING_TABLE
     logger.info("Deleted pricing override: %s/%s (static fallback: %s)", provider, model, has_static)
-    return _build_response(
-        200,
-        {
-            "message": f"Price override deleted: {provider}/{model}",
-            "static_fallback": has_static,
-        },
+    _audit(
+        event,
+        principal,
+        action="pricing.delete",
+        resource=f"{provider}/{model}",
+        detail=f"static_fallback={has_static}",
     )
-
-
-# -- Response builder ----------------------------------------------------------
-
-
-def _build_response(status_code: int, body: dict[str, Any]) -> dict[str, Any]:
-    """Build a Lambda Function URL response."""
-    return {
-        "statusCode": status_code,
-        "headers": {"Content-Type": "application/json"},
-        "body": json.dumps(body, default=str),
-    }
+    return ok({"message": f"Price override deleted: {provider}/{model}", "static_fallback": has_static})
 
 
 # -- Lambda entry point --------------------------------------------------------
 
 
-def handler(event: dict[str, Any], _context: Any = None) -> dict[str, Any]:
-    """Lambda Function URL handler for pricing admin CRUD.
+def handler(event: dict[str, Any], _context: Any = None) -> dict[str, Any]:  # noqa: PLR0911 — one return per CRUD route
+    """Lambda handler for pricing admin CRUD (admin scope required)."""
+    cid = correlation_id(event)
+    log = bind(logger, cid)
+    path, method = _path_method(event)
 
-    Routes:
-        GET    /pricing                      -- list all prices (DDB + static merged)
-        GET    /pricing/{provider}/{model}   -- get a specific price
-        PUT    /pricing/{provider}/{model}   -- upsert a pricing entry
-        DELETE /pricing/{provider}/{model}   -- delete a pricing override
-    """
-    path, method = _extract_path_and_method(event)
-    provider, model = _extract_provider_model(path)
+    if path == "/health" and method == "GET":
+        return ok({"status": "healthy"})
 
-    if method == "GET" and provider is None:
-        return _handle_list_prices()
+    try:
+        with Timer("RequestLatency", route="pricing_admin"):
+            principal = auth.build_principal(event)
+            auth.require(principal, scopes=[auth.ADMIN_SCOPE])
+            provider, model = _provider_model(path)
 
-    if method == "GET" and provider is not None and model is not None:
-        return _handle_get_price(provider, model)
-
-    if method == "PUT" and provider is not None and model is not None:
-        return _handle_upsert_price(provider, model, event)
-
-    if method == "DELETE" and provider is not None and model is not None:
-        return _handle_delete_price(provider, model)
-
-    return _build_response(405, {"error": f"Method not allowed: {method} {path}"})
+            if method == "GET" and provider is None:
+                return _list_prices()
+            if method == "GET" and provider and model:
+                return _get_price(provider, model)
+            if method == "PUT" and provider and model:
+                return _upsert_price(provider, model, event, principal)
+            if method == "DELETE" and provider and model:
+                return _delete_price(provider, model, event, principal)
+            raise errors.NotFoundError(f"Not found: {method} {path}")  # noqa: TRY301 — dispatch fallthrough
+    except errors.ControlPlaneError as exc:
+        if exc.status in {401, 403}:
+            emit_metric("AuthzDenied", 1, dimensions={"Route": "pricing_admin"})
+            actor = "unknown"
+            with contextlib.suppress(errors.ControlPlaneError):
+                actor = auth.build_principal(event).sub or "unknown"
+            audit.emit(
+                audit.event_from_request(
+                    event,
+                    action="pricing.access",
+                    actor=actor,
+                    resource=f"{method} {path}",
+                    decision="deny",
+                    status=exc.status,
+                    detail=exc.code,
+                )
+            )
+        return responses.error_response(exc)
+    except Exception:
+        log.exception("Unhandled error in pricing_admin: %s %s", method, path)
+        emit_metric("PricingAdminError", 1, dimensions={"Code": "internal_error"})
+        return responses.error_response(errors.ControlPlaneError("Internal error"))

--- a/src/routing_config/handler.py
+++ b/src/routing_config/handler.py
@@ -1,14 +1,22 @@
-"""Routing config Lambda (Function URL).
+"""Routing config Lambda — Portkey routing strategies, migrated onto gwcore (ADR-016).
 
-Serves routing configurations dynamically:
-- Built-in configs are loaded from the portkey-configs directory (read-only).
-- Custom configs are stored in and served from DynamoDB.
+Built-in configs load from the portkey-configs directory (read-only); custom
+configs live in DynamoDB. Authorization is now enforced in-handler (it was not):
+every request requires the admin scope, and the create / update / delete
+mutations emit audit events.
+
+Routes:
+    GET    /routing/configs         -- list all configs
+    GET    /routing/configs/{name}  -- get a specific config
+    POST   /routing/configs         -- create a custom config
+    PUT    /routing/configs/{name}  -- update a custom config
+    DELETE /routing/configs/{name}  -- delete a custom config
 """
 
 from __future__ import annotations
 
+import contextlib
 import json
-import logging
 import os
 from datetime import UTC, datetime
 from pathlib import Path
@@ -18,29 +26,17 @@ import boto3
 from botocore.exceptions import ClientError
 from pydantic import ValidationError
 
+from gwcore import audit, auth, errors, ok, responses
+from gwcore.logging import bind, correlation_id, get_logger
+from gwcore.responses import request_body
+from gwcore.telemetry import Timer, emit_metric
 from routing_config.models import (
     _MIN_PATH_PARTS_WITH_NAME,
     RoutingConfig,
     RoutingConfigSummary,
 )
 
-logger = logging.getLogger("routing_config")
-logger.setLevel(logging.INFO)
-if not logger.handlers:
-    _h = logging.StreamHandler()
-    _h.setFormatter(
-        logging.Formatter(
-            json.dumps(
-                {
-                    "timestamp": "%(asctime)s",
-                    "level": "%(levelname)s",
-                    "logger": "%(name)s",
-                    "message": "%(message)s",
-                }
-            )
-        )
-    )
-    logger.addHandler(_h)
+logger = get_logger("routing_config")
 
 CONFIGS_TABLE = os.environ.get("ROUTING_CONFIGS_TABLE", "gateway-routing-configs")
 CONFIGS_DIR = os.environ.get(
@@ -65,11 +61,9 @@ def _load_builtin_configs() -> dict[str, dict[str, Any]]:
     for config_file in sorted(configs_path.glob("*.json")):
         try:
             data = json.loads(config_file.read_text())
-            name = config_file.stem
-            configs[name] = data
+            configs[config_file.stem] = data
         except (json.JSONDecodeError, OSError):
             logger.exception("Failed to load config file: %s", config_file)
-
     return configs
 
 
@@ -78,7 +72,7 @@ _BUILTIN_CONFIGS: dict[str, dict[str, Any]] | None = None
 
 def _get_builtin_configs() -> dict[str, dict[str, Any]]:
     """Get built-in configs (cached after first load)."""
-    global _BUILTIN_CONFIGS  # noqa: PLW0603
+    global _BUILTIN_CONFIGS  # noqa: PLW0603 — module-scoped cache for warm Lambda
     if _BUILTIN_CONFIGS is None:
         _BUILTIN_CONFIGS = _load_builtin_configs()
     return _BUILTIN_CONFIGS
@@ -88,17 +82,15 @@ def _get_builtin_configs() -> dict[str, dict[str, Any]]:
 
 
 def _get_custom_config(name: str) -> dict[str, Any] | None:
-    """Fetch a custom routing config from DynamoDB."""
     table = dynamodb.Table(CONFIGS_TABLE)
-    resp = table.get_item(Key={"config_name": name})
-    item = resp.get("Item")
+    item = table.get_item(Key={"config_name": name}).get("Item")
     if not item:
         return None
-    return json.loads(item["config_json"]) if isinstance(item.get("config_json"), str) else item.get("config_json")
+    cfg = item.get("config_json")
+    return json.loads(cfg) if isinstance(cfg, str) else cfg
 
 
 def _list_custom_configs() -> list[dict[str, Any]]:
-    """List all custom routing configs from DynamoDB."""
     table = dynamodb.Table(CONFIGS_TABLE)
     resp = table.scan(
         ProjectionExpression="config_name, strategy_mode, target_count, description, created_by, updated_at",
@@ -107,7 +99,6 @@ def _list_custom_configs() -> list[dict[str, Any]]:
 
 
 def _put_custom_config(name: str, config: RoutingConfig) -> None:
-    """Store a custom routing config in DynamoDB."""
     table = dynamodb.Table(CONFIGS_TABLE)
     now = datetime.now(tz=UTC).isoformat()
     table.put_item(
@@ -126,72 +117,66 @@ def _put_custom_config(name: str, config: RoutingConfig) -> None:
 
 
 def _delete_custom_config(name: str) -> bool:
-    """Delete a custom routing config from DynamoDB. Returns True if it existed."""
+    """Delete a custom routing config. Returns True if it existed."""
     table = dynamodb.Table(CONFIGS_TABLE)
     try:
-        table.delete_item(
-            Key={"config_name": name},
-            ConditionExpression="attribute_exists(config_name)",
-        )
+        table.delete_item(Key={"config_name": name}, ConditionExpression="attribute_exists(config_name)")
     except ClientError as e:
-        error_code = e.response.get("Error", {}).get("Code", "")
-        if error_code == "ConditionalCheckFailedException":
+        if e.response.get("Error", {}).get("Code", "") == "ConditionalCheckFailedException":
             return False
         raise
-    else:
-        return True
+    return True
 
 
-# -- Route handling ------------------------------------------------------------
+# -- Route helpers -------------------------------------------------------------
 
 
-def _extract_path_and_method(event: dict[str, Any]) -> tuple[str, str]:
-    """Extract HTTP method and path from a Lambda Function URL event."""
-    request_context = event.get("requestContext", {})
-    http = request_context.get("http", {})
-    method = http.get("method", "GET").upper()
-    raw_path = http.get("path", event.get("rawPath", "/"))
-    return raw_path, method
+def _path_method(event: dict[str, Any]) -> tuple[str, str]:
+    http = event.get("requestContext", {}).get("http", {})
+    method = event.get("httpMethod") or http.get("method", "GET")
+    path = http.get("path") or event.get("path") or event.get("rawPath", "/")
+    return str(path), str(method).upper()
 
 
-def _parse_body(event: dict[str, Any]) -> dict[str, Any]:
-    """Parse JSON body from Lambda Function URL event."""
-    body_str = event.get("body", "{}")
-    if event.get("isBase64Encoded"):
-        import base64  # noqa: PLC0415
-
-        body_str = base64.b64decode(body_str).decode()
-    return json.loads(body_str) if isinstance(body_str, str) else body_str
-
-
-def _extract_config_name(path: str) -> str | None:
-    """Extract config name from path (e.g. /routing/configs/cost-optimized)."""
+def _config_name(path: str) -> str | None:
     parts = [p for p in path.strip("/").split("/") if p]
     if len(parts) >= _MIN_PATH_PARTS_WITH_NAME and parts[0] == "routing" and parts[1] == "configs":
         return parts[2]
     return None
 
 
-def _handle_list_configs() -> dict[str, Any]:
-    """GET /routing/configs -- list all available routing strategies."""
-    builtin = _get_builtin_configs()
-    summaries: list[dict[str, Any]] = []
+def _audit(event: dict[str, Any], principal: auth.Principal, **kw: Any) -> None:
+    audit.emit(audit.event_from_request(event, actor=principal.sub, team=principal.team, **kw))
 
-    for name, config_data in sorted(builtin.items()):
+
+def _validate_body(event: dict[str, Any]) -> dict[str, Any]:
+    try:
+        body = json.loads(request_body(event))
+    except (json.JSONDecodeError, ValueError) as e:
+        raise errors.ValidationFailedError("Invalid JSON body") from e
+    if not isinstance(body, dict):
+        raise errors.ValidationFailedError("Request body must be a JSON object")
+    return body
+
+
+# -- Route handlers ------------------------------------------------------------
+
+
+def _list_configs() -> dict[str, Any]:
+    """GET /routing/configs — built-in + custom config summaries."""
+    summaries: list[dict[str, Any]] = []
+    for name, config_data in sorted(_get_builtin_configs().items()):
         strategy = config_data.get("strategy", {})
-        targets = config_data.get("targets", [])
         summaries.append(
             RoutingConfigSummary(
                 name=name,
                 mode=strategy.get("mode", "unknown"),
-                target_count=len(targets),
+                target_count=len(config_data.get("targets", [])),
                 builtin=True,
                 description=f"Built-in {strategy.get('mode', '')} routing config",
             ).model_dump()
         )
-
     try:
-        custom_items = _list_custom_configs()
         summaries.extend(
             RoutingConfigSummary(
                 name=item["config_name"],
@@ -200,202 +185,154 @@ def _handle_list_configs() -> dict[str, Any]:
                 builtin=False,
                 description=item.get("description", ""),
             ).model_dump()
-            for item in custom_items
+            for item in _list_custom_configs()
         )
-    except Exception:
+    except ClientError:
         logger.exception("Failed to list custom configs from DynamoDB")
+    return ok({"configs": summaries, "total": len(summaries)})
 
-    return _build_response(200, {"configs": summaries, "total": len(summaries)})
 
-
-def _handle_get_config(name: str) -> dict[str, Any]:
-    """GET /routing/configs/{name} -- get a specific config."""
+def _get_config(name: str) -> dict[str, Any]:
+    """GET /routing/configs/{name} — built-in first, then custom."""
     builtin = _get_builtin_configs()
     if name in builtin:
-        return _build_response(
-            200,
-            {
-                "name": name,
-                "builtin": True,
-                "config": builtin[name],
-            },
-        )
-
+        return ok({"name": name, "builtin": True, "config": builtin[name]})
     try:
         custom = _get_custom_config(name)
-        if custom:
-            return _build_response(
-                200,
-                {
-                    "name": name,
-                    "builtin": False,
-                    "config": custom,
-                },
-            )
-    except Exception:
-        logger.exception("Failed to fetch custom config: %s", name)
-        return _build_response(500, {"error": "Failed to fetch config from storage"})
-
-    return _build_response(404, {"error": f"Routing config not found: {name}"})
+    except ClientError as e:
+        raise errors.UpstreamError("Failed to fetch config from storage") from e
+    if custom:
+        return ok({"name": name, "builtin": False, "config": custom})
+    raise errors.NotFoundError(f"Routing config not found: {name}")
 
 
-def _handle_create_config(event: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0911
-    """POST /routing/configs -- create a new custom config."""
-    try:
-        body = _parse_body(event)
-    except Exception:
-        return _build_response(400, {"error": "Invalid JSON body"})
-
-    if not isinstance(body, dict):
-        return _build_response(400, {"error": "Request body must be a JSON object"})
-
+def _create_config(event: dict[str, Any], principal: auth.Principal) -> dict[str, Any]:
+    """POST /routing/configs — create a new custom config."""
+    body = _validate_body(event)
     name = body.pop("name", None)
     if not name or not isinstance(name, str):
-        return _build_response(400, {"error": "Missing required field: name"})
-
+        raise errors.ValidationFailedError("Missing required field: name")
     if name in _get_builtin_configs():
-        return _build_response(409, {"error": f"Cannot create config with built-in name: {name}"})
-
+        raise errors.ConflictError(f"Cannot create config with built-in name: {name}")
     try:
-        existing = _get_custom_config(name)
-        if existing:
-            return _build_response(409, {"error": f"Config already exists: {name}. Use PUT to update."})
-    except Exception:
-        logger.exception("Failed to check existing config: %s", name)
-        return _build_response(500, {"error": "Storage error during conflict check"})
+        if _get_custom_config(name):
+            raise errors.ConflictError(f"Config already exists: {name}. Use PUT to update.")
+    except ClientError as e:
+        raise errors.UpstreamError("Storage error during conflict check") from e
 
     try:
         config = RoutingConfig.model_validate(body)
     except ValidationError as e:
-        return _build_response(400, {"error": f"Validation failed: {e.error_count()} errors", "details": e.errors()})
+        raise errors.ValidationFailedError("Invalid routing config", details={"errors": e.errors()}) from e
 
     now = datetime.now(tz=UTC).isoformat()
     config.metadata.created_at = now
     config.metadata.updated_at = now
-
     try:
         _put_custom_config(name, config)
-    except Exception:
-        logger.exception("Failed to store config: %s", name)
-        return _build_response(500, {"error": "Failed to store config"})
+    except ClientError as e:
+        raise errors.UpstreamError("Failed to store config") from e
 
     logger.info("Created custom routing config: %s", name)
-    return _build_response(
-        201,
-        {
-            "name": name,
-            "config": config.to_portkey_config(),
-            "message": "Config created successfully",
-        },
+    _audit(event, principal, action="routing.create", resource=name, status=201)
+    return ok(
+        {"name": name, "config": config.to_portkey_config(), "message": "Config created successfully"},
+        status=201,
     )
 
 
-def _handle_update_config(name: str, event: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0911
-    """PUT /routing/configs/{name} -- update a custom config."""
+def _update_config(name: str, event: dict[str, Any], principal: auth.Principal) -> dict[str, Any]:
+    """PUT /routing/configs/{name} — update a custom config."""
     if name in _get_builtin_configs():
-        return _build_response(403, {"error": f"Cannot modify built-in config: {name}"})
-
-    try:
-        body = _parse_body(event)
-    except Exception:
-        return _build_response(400, {"error": "Invalid JSON body"})
-
-    if not isinstance(body, dict):
-        return _build_response(400, {"error": "Request body must be a JSON object"})
-
+        raise errors.ForbiddenError(f"Cannot modify built-in config: {name}")
+    body = _validate_body(event)
     try:
         config = RoutingConfig.model_validate(body)
     except ValidationError as e:
-        return _build_response(400, {"error": f"Validation failed: {e.error_count()} errors", "details": e.errors()})
+        raise errors.ValidationFailedError("Invalid routing config", details={"errors": e.errors()}) from e
 
     try:
-        existing = _get_custom_config(name)
-        if not existing:
-            return _build_response(404, {"error": f"Config not found: {name}. Use POST to create."})
-    except Exception:
-        logger.exception("Failed to check config existence: %s", name)
-        return _build_response(500, {"error": "Storage error during existence check"})
+        if not _get_custom_config(name):
+            raise errors.NotFoundError(f"Config not found: {name}. Use POST to create.")
+    except ClientError as e:
+        raise errors.UpstreamError("Storage error during existence check") from e
 
-    now = datetime.now(tz=UTC).isoformat()
-    config.metadata.updated_at = now
+    config.metadata.updated_at = datetime.now(tz=UTC).isoformat()
     config.metadata.version += 1
-
     try:
         _put_custom_config(name, config)
-    except Exception:
-        logger.exception("Failed to update config: %s", name)
-        return _build_response(500, {"error": "Failed to update config"})
+    except ClientError as e:
+        raise errors.UpstreamError("Failed to update config") from e
 
     logger.info("Updated custom routing config: %s (v%d)", name, config.metadata.version)
-    return _build_response(
-        200,
-        {
-            "name": name,
-            "config": config.to_portkey_config(),
-            "message": "Config updated successfully",
-        },
-    )
+    _audit(event, principal, action="routing.update", resource=name, detail=f"v{config.metadata.version}")
+    return ok({"name": name, "config": config.to_portkey_config(), "message": "Config updated successfully"})
 
 
-def _handle_delete_config(name: str) -> dict[str, Any]:
-    """DELETE /routing/configs/{name} -- delete a custom config."""
+def _delete_config(name: str, event: dict[str, Any], principal: auth.Principal) -> dict[str, Any]:
+    """DELETE /routing/configs/{name} — delete a custom config."""
     if name in _get_builtin_configs():
-        return _build_response(403, {"error": f"Cannot delete built-in config: {name}"})
-
+        raise errors.ForbiddenError(f"Cannot delete built-in config: {name}")
     try:
         deleted = _delete_custom_config(name)
-    except Exception:
-        logger.exception("Failed to delete config: %s", name)
-        return _build_response(500, {"error": "Failed to delete config"})
-
+    except ClientError as e:
+        raise errors.UpstreamError("Failed to delete config") from e
     if not deleted:
-        return _build_response(404, {"error": f"Config not found: {name}"})
+        raise errors.NotFoundError(f"Config not found: {name}")
 
     logger.info("Deleted custom routing config: %s", name)
-    return _build_response(200, {"message": f"Config deleted: {name}"})
-
-
-# -- Response builder ----------------------------------------------------------
-
-
-def _build_response(status_code: int, body: dict[str, Any]) -> dict[str, Any]:
-    """Build a Lambda Function URL response."""
-    return {
-        "statusCode": status_code,
-        "headers": {"Content-Type": "application/json"},
-        "body": json.dumps(body, default=str),
-    }
+    _audit(event, principal, action="routing.delete", resource=name)
+    return ok({"message": f"Config deleted: {name}"})
 
 
 # -- Lambda entry point --------------------------------------------------------
 
 
-def handler(event: dict[str, Any], _context: Any = None) -> dict[str, Any]:
-    """Lambda Function URL handler for routing config CRUD.
+def handler(event: dict[str, Any], _context: Any = None) -> dict[str, Any]:  # noqa: PLR0911 — one return per CRUD route
+    """Lambda handler for routing config CRUD (admin scope required)."""
+    cid = correlation_id(event)
+    log = bind(logger, cid)
+    path, method = _path_method(event)
 
-    Routes:
-        GET  /routing/configs         -- list all configs
-        GET  /routing/configs/{name}  -- get a specific config
-        POST /routing/configs         -- create a custom config
-        PUT  /routing/configs/{name}  -- update a custom config
-        DELETE /routing/configs/{name} -- delete a custom config
-    """
-    path, method = _extract_path_and_method(event)
-    config_name = _extract_config_name(path)
+    if path == "/health" and method == "GET":
+        return ok({"status": "healthy"})
 
-    if method == "GET" and config_name is None:
-        return _handle_list_configs()
+    try:
+        with Timer("RequestLatency", route="routing_config"):
+            principal = auth.build_principal(event)
+            auth.require(principal, scopes=[auth.ADMIN_SCOPE])
+            name = _config_name(path)
 
-    if method == "GET" and config_name is not None:
-        return _handle_get_config(config_name)
-
-    if method == "POST" and config_name is None:
-        return _handle_create_config(event)
-
-    if method == "PUT" and config_name is not None:
-        return _handle_update_config(config_name, event)
-
-    if method == "DELETE" and config_name is not None:
-        return _handle_delete_config(config_name)
-
-    return _build_response(405, {"error": f"Method not allowed: {method} {path}"})
+            if method == "GET" and name is None:
+                return _list_configs()
+            if method == "GET" and name is not None:
+                return _get_config(name)
+            if method == "POST" and name is None:
+                return _create_config(event, principal)
+            if method == "PUT" and name is not None:
+                return _update_config(name, event, principal)
+            if method == "DELETE" and name is not None:
+                return _delete_config(name, event, principal)
+            raise errors.NotFoundError(f"Not found: {method} {path}")  # noqa: TRY301 — dispatch fallthrough
+    except errors.ControlPlaneError as exc:
+        if exc.status in {401, 403}:
+            emit_metric("AuthzDenied", 1, dimensions={"Route": "routing_config"})
+            actor = "unknown"
+            with contextlib.suppress(errors.ControlPlaneError):
+                actor = auth.build_principal(event).sub or "unknown"
+            audit.emit(
+                audit.event_from_request(
+                    event,
+                    action="routing.access",
+                    actor=actor,
+                    resource=f"{method} {path}",
+                    decision="deny",
+                    status=exc.status,
+                    detail=exc.code,
+                )
+            )
+        return responses.error_response(exc)
+    except Exception:
+        log.exception("Unhandled error in routing_config: %s %s", method, path)
+        emit_metric("RoutingConfigError", 1, dimensions={"Code": "internal_error"})
+        return responses.error_response(errors.ControlPlaneError("Internal error"))

--- a/src/routing_config/handler.py
+++ b/src/routing_config/handler.py
@@ -15,7 +15,6 @@ Routes:
 
 from __future__ import annotations
 
-import contextlib
 import json
 import os
 from datetime import UTC, datetime
@@ -317,9 +316,10 @@ def handler(event: dict[str, Any], _context: Any = None) -> dict[str, Any]:  # n
     except errors.ControlPlaneError as exc:
         if exc.status in {401, 403}:
             emit_metric("AuthzDenied", 1, dimensions={"Route": "routing_config"})
-            actor = "unknown"
-            with contextlib.suppress(errors.ControlPlaneError):
+            try:
                 actor = auth.build_principal(event).sub or "unknown"
+            except errors.ControlPlaneError:
+                actor = "unknown"
             audit.emit(
                 audit.event_from_request(
                     event,

--- a/src/usage_api/handler.py
+++ b/src/usage_api/handler.py
@@ -1,16 +1,16 @@
-"""Real-time usage self-service API Lambda handler.
+"""Real-time usage self-service API — migrated onto gwcore (ADR-016).
 
-Provides read-only access to team usage data stored in DynamoDB:
-- Current period usage for a team
-- Trailing N months of usage history
-- Per-model usage breakdown for the current period
-- Budget utilization percentage (when a budget config exists)
+Read-only access to team usage data in DynamoDB (current period, trailing
+history, per-model breakdown, budget utilization).
+
+Tenant isolation is now enforced (it was not): a caller may read only their
+OWN team's usage — ``principal.team`` from the token must match the requested
+``team`` — unless they hold the admin scope. Previously any authenticated
+caller could read any team's usage/spend via the ``team`` query param.
 """
 
 from __future__ import annotations
 
-import json
-import logging
 import os
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
@@ -20,25 +20,12 @@ import boto3
 from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
 
+from gwcore import auth, errors, ok, responses
+from gwcore.logging import bind, correlation_id, get_logger
+from gwcore.telemetry import Timer, emit_metric
 from usage_api.models import ModelUsage, UsagePeriod, UsageResponse
 
-logger = logging.getLogger("usage_api")
-logger.setLevel(logging.INFO)
-if not logger.handlers:
-    _h = logging.StreamHandler()
-    _h.setFormatter(
-        logging.Formatter(
-            json.dumps(
-                {
-                    "timestamp": "%(asctime)s",
-                    "level": "%(levelname)s",
-                    "logger": "%(name)s",
-                    "message": "%(message)s",
-                }
-            )
-        )
-    )
-    logger.addHandler(_h)
+logger = get_logger("usage_api")
 
 USAGE_TABLE = os.environ.get("USAGE_TABLE", "gateway-usage")
 BUDGETS_TABLE = os.environ.get("BUDGETS_TABLE", "gateway-budgets")
@@ -156,66 +143,50 @@ def _safe_decimal(value: Any) -> Decimal:
         return Decimal("0.00")
 
 
-# -- Route handlers ------------------------------------------------------------
+# -- Route handler -------------------------------------------------------------
 
 
 def _handle_usage(team: str, history: int, models: bool) -> dict[str, Any]:
     """Core handler logic: fetch usage data and build the response."""
     period = _current_period()
 
-    # Fetch current period usage
     try:
         current_item = _get_team_usage(team, period)
-    except (ClientError, Exception):
-        logger.exception("Failed to query current usage for team=%s", team)
-        return _build_response(502, {"error": "Failed to query usage data"})
+    except ClientError as e:
+        raise errors.UpstreamError("Failed to query usage data") from e
 
     current_period = _item_to_usage_period(current_item, period) if current_item else None
 
-    # Fetch budget config for utilization calculation
     budget_utilization_pct: float | None = None
     monthly_budget_usd: Decimal | None = None
     try:
         budget_item = _get_budget_config(team)
         if budget_item:
-            raw_budget = budget_item.get("monthly_budget_usd", "0")
-            monthly_budget_usd = _safe_decimal(raw_budget)
+            monthly_budget_usd = _safe_decimal(budget_item.get("monthly_budget_usd", "0"))
             if monthly_budget_usd > 0 and current_period:
-                budget_utilization_pct = round(
-                    float(current_period.total_cost_usd / monthly_budget_usd * 100),
-                    1,
-                )
-    except (ClientError, Exception):
+                budget_utilization_pct = round(float(current_period.total_cost_usd / monthly_budget_usd * 100), 1)
+    except ClientError:
+        # Non-fatal: still return usage data without budget info.
         logger.exception("Failed to query budget config for team=%s", team)
-        # Non-fatal: we still return usage data without budget info
 
-    # Build history if requested
     usage_history: list[UsagePeriod] = []
     if history > 0:
-        periods = _trailing_periods(history)
-        for p in periods:
+        for p in _trailing_periods(history):
             try:
                 item = _get_team_usage(team, p)
-                if item:
-                    usage_history.append(_item_to_usage_period(item, p))
-            except (ClientError, Exception):
-                logger.exception("Failed to query usage for team=%s period=%s", team, p)
-                return _build_response(502, {"error": "Failed to query usage data"})
+            except ClientError as e:
+                raise errors.UpstreamError("Failed to query usage data") from e
+            if item:
+                usage_history.append(_item_to_usage_period(item, p))
 
-    # Build model breakdown if requested
     model_list: list[ModelUsage] = []
     if models:
         try:
             model_items = _get_model_usage_for_team(team, period)
-            for item in model_items:
-                mu = _item_to_model_usage(item)
-                if mu:
-                    model_list.append(mu)
-            # Sort by cost descending for convenience
-            model_list.sort(key=lambda m: m.total_cost_usd, reverse=True)
-        except (ClientError, Exception):
-            logger.exception("Failed to query model usage for team=%s", team)
-            return _build_response(502, {"error": "Failed to query usage data"})
+        except ClientError as e:
+            raise errors.UpstreamError("Failed to query usage data") from e
+        model_list = [mu for item in model_items if (mu := _item_to_model_usage(item))]
+        model_list.sort(key=lambda m: m.total_cost_usd, reverse=True)
 
     response = UsageResponse(
         team=team,
@@ -225,47 +196,59 @@ def _handle_usage(team: str, history: int, models: bool) -> dict[str, Any]:
         budget_utilization_pct=budget_utilization_pct,
         monthly_budget_usd=monthly_budget_usd,
     )
-
-    return _build_response(200, response.model_dump(mode="json"))
-
-
-# -- Response builder ----------------------------------------------------------
-
-
-def _build_response(status_code: int, body: dict[str, Any]) -> dict[str, Any]:
-    """Build a Lambda Function URL response."""
-    return {
-        "statusCode": status_code,
-        "headers": {"Content-Type": "application/json"},
-        "body": json.dumps(body, default=str),
-    }
+    return ok(response.model_dump(mode="json"))
 
 
 # -- Lambda entry point --------------------------------------------------------
 
 
 def handler(event: dict[str, Any], _context: Any = None) -> dict[str, Any]:
-    """Lambda Function URL handler for the usage self-service API.
+    """Lambda handler for the usage self-service API.
 
     Routes:
         GET /usage?team=X              -- current period usage for team X
         GET /usage?team=X&history=N    -- trailing N months of usage history
         GET /usage?team=X&models=true  -- per-model breakdown for current period
     """
-    params = event.get("queryStringParameters") or {}
-    team = params.get("team", "")
+    cid = correlation_id(event)
+    log = bind(logger, cid)
 
-    if not team:
-        return _build_response(400, {"error": "Missing required parameter: team"})
+    if (event.get("rawPath") or event.get("path") or "") == "/health":
+        return ok({"status": "healthy"})
 
-    history = 0
     try:
-        history = int(params.get("history", "0"))
-    except (ValueError, TypeError):
-        history = 0
+        with Timer("RequestLatency", route="usage_api"):
+            principal = auth.build_principal(event)
+            auth.require(principal, scopes=[auth.INVOKE_SCOPE])
 
-    models = params.get("models", "").lower() == "true"
+            params = event.get("queryStringParameters") or {}
+            team = params.get("team", "")
+            if not team:
+                msg = "Missing required parameter: team"
+                raise errors.ValidationFailedError(msg)  # noqa: TRY301 — direct request guard
 
-    logger.info("Usage request: team=%s history=%d models=%s", team, history, models)
+            # Tenant isolation: a caller may read only their own team's usage
+            # unless they hold the admin scope.
+            if not principal.is_admin and principal.team and principal.team != team:
+                emit_metric("AuthzDenied", 1, dimensions={"Route": "usage_api"})
+                msg = "Cannot read usage for another team"
+                raise errors.ForbiddenError(  # noqa: TRY301 — direct tenant-isolation guard
+                    msg, details={"requested": team, "your_team": principal.team}
+                )
 
-    return _handle_usage(team, history, models)
+            try:
+                history = int(params.get("history", "0"))
+            except (ValueError, TypeError):
+                history = 0
+            models = params.get("models", "").lower() == "true"
+
+            log.info("usage request: team=%s history=%d models=%s by=%s", team, history, models, principal.sub)
+            return _handle_usage(team, history, models)
+    except errors.ControlPlaneError as exc:
+        if exc.status in {401, 403}:
+            emit_metric("AuthzDenied", 1, dimensions={"Route": "usage_api"})
+        return responses.error_response(exc)
+    except Exception:
+        log.exception("Unhandled error in usage_api")
+        emit_metric("UsageApiError", 1, dimensions={"Code": "internal_error"})
+        return responses.error_response(errors.ControlPlaneError("Internal error"))

--- a/src/usage_api/handler.py
+++ b/src/usage_api/handler.py
@@ -250,7 +250,6 @@ def handler(event: dict[str, Any], _context: Any = None) -> dict[str, Any]:
     except errors.ControlPlaneError as exc:
         if exc.status in {401, 403}:
             emit_metric("AuthzDenied", 1, dimensions={"Route": "usage_api"})
-            actor = "unknown"
             try:
                 actor = auth.build_principal(event).sub or "unknown"
             except errors.ControlPlaneError:

--- a/src/usage_api/handler.py
+++ b/src/usage_api/handler.py
@@ -20,7 +20,7 @@ import boto3
 from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
 
-from gwcore import auth, errors, ok, responses
+from gwcore import audit, auth, errors, ok, responses
 from gwcore.logging import bind, correlation_id, get_logger
 from gwcore.telemetry import Timer, emit_metric
 from usage_api.models import ModelUsage, UsagePeriod, UsageResponse
@@ -213,7 +213,9 @@ def handler(event: dict[str, Any], _context: Any = None) -> dict[str, Any]:
     cid = correlation_id(event)
     log = bind(logger, cid)
 
-    if (event.get("rawPath") or event.get("path") or "") == "/health":
+    method = (event.get("requestContext", {}).get("http", {}).get("method") or event.get("httpMethod") or "GET").upper()
+    path = event.get("rawPath") or event.get("path") or ""
+    if path == "/health" and method == "GET":
         return ok({"status": "healthy"})
 
     try:
@@ -227,10 +229,11 @@ def handler(event: dict[str, Any], _context: Any = None) -> dict[str, Any]:
                 msg = "Missing required parameter: team"
                 raise errors.ValidationFailedError(msg)  # noqa: TRY301 — direct request guard
 
-            # Tenant isolation: a caller may read only their own team's usage
-            # unless they hold the admin scope.
-            if not principal.is_admin and principal.team and principal.team != team:
-                emit_metric("AuthzDenied", 1, dimensions={"Route": "usage_api"})
+            # Tenant isolation: a non-admin may read only their OWN team's usage.
+            # A non-admin whose token carries a different (or empty) team claim is
+            # denied — an empty claim must not bypass the check, or it would grant
+            # cross-team reads via the ?team= param.
+            if not principal.is_admin and principal.team != team:
                 msg = "Cannot read usage for another team"
                 raise errors.ForbiddenError(  # noqa: TRY301 — direct tenant-isolation guard
                     msg, details={"requested": team, "your_team": principal.team}
@@ -247,6 +250,22 @@ def handler(event: dict[str, Any], _context: Any = None) -> dict[str, Any]:
     except errors.ControlPlaneError as exc:
         if exc.status in {401, 403}:
             emit_metric("AuthzDenied", 1, dimensions={"Route": "usage_api"})
+            actor = "unknown"
+            try:
+                actor = auth.build_principal(event).sub or "unknown"
+            except errors.ControlPlaneError:
+                actor = "unknown"
+            audit.emit(
+                audit.event_from_request(
+                    event,
+                    action="usage.access",
+                    actor=actor,
+                    resource=f"{method} {path or '/usage'}",
+                    decision="deny",
+                    status=exc.status,
+                    detail=exc.code,
+                )
+            )
         return responses.error_response(exc)
     except Exception:
         log.exception("Unhandled error in usage_api")

--- a/tests/test_pricing_admin.py
+++ b/tests/test_pricing_admin.py
@@ -586,6 +586,23 @@ class TestUnsupportedMethod:
         assert result["statusCode"] == 404
 
 
+class TestHandlerInfra:
+    """Health route and the catch-all (non-ControlPlaneError → 500)."""
+
+    def test_health_check(self) -> None:
+        event = {"requestContext": {"http": {"method": "GET", "path": "/health"}}, "rawPath": "/health"}
+        result = handler(event)
+        assert result["statusCode"] == 200
+        assert _parse_body(result)["status"] == "healthy"
+
+    @patch("pricing_admin.handler._list_prices")
+    def test_unhandled_error_returns_500(self, mock_list: Any) -> None:
+        mock_list.side_effect = RuntimeError("boom")
+        result = handler(_make_event(method="GET", path="/pricing"))
+        assert result["statusCode"] == 500
+        assert _parse_body(result)["error"]["code"] == "internal_error"
+
+
 # -- Response format -----------------------------------------------------------
 
 

--- a/tests/test_pricing_admin.py
+++ b/tests/test_pricing_admin.py
@@ -24,16 +24,30 @@ from pricing_admin.models import PriceEntry, PriceSummary
 # -- Helpers ------------------------------------------------------------------
 
 
+ADMIN_SCOPE = "https://gateway.internal/admin"
+
+
+def _make_jwt(claims: dict[str, Any]) -> str:
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).decode().rstrip("=")
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    return f"{header}.{payload}.sig"
+
+
+_ADMIN_JWT = _make_jwt({"sub": "admin-user", "scope": ADMIN_SCOPE})
+
+
 def _make_event(
     method: str = "GET",
     path: str = "/pricing",
     body: dict[str, Any] | str | None = None,
     is_base64: bool = False,
+    token: str | None = None,
 ) -> dict[str, Any]:
-    """Build a Lambda Function URL event."""
+    """Build an API Gateway event with an admin bearer by default."""
     event: dict[str, Any] = {
-        "requestContext": {"http": {"method": method, "path": path}},
+        "requestContext": {"requestId": "rid-test", "http": {"method": method, "path": path}},
         "isBase64Encoded": is_base64,
+        "headers": {"authorization": f"Bearer {token or _ADMIN_JWT}"},
     }
     if body is not None:
         event["body"] = json.dumps(body) if isinstance(body, dict) else body
@@ -45,6 +59,21 @@ def _make_event(
 def _parse_body(response: dict[str, Any]) -> dict[str, Any]:
     """Parse the JSON body from a Lambda response."""
     return json.loads(response["body"])
+
+
+# -- Authorization (now enforced via gwcore, ADR-016) -------------------------
+
+
+class TestAuthorization:
+    def test_missing_auth_401(self) -> None:
+        event = {"requestContext": {"http": {"method": "GET", "path": "/pricing"}}, "headers": {}, "body": ""}
+        assert handler(event)["statusCode"] == 401
+
+    def test_non_admin_403(self) -> None:
+        token = _make_jwt({"sub": "u", "scope": "https://gateway.internal/invoke"})
+        result = handler(_make_event(method="GET", path="/pricing", token=token))
+        assert result["statusCode"] == 403
+        assert _parse_body(result)["error"]["code"] == "forbidden"
 
 
 # -- Model tests --------------------------------------------------------------
@@ -263,7 +292,7 @@ class TestGetPrice:
         assert result["statusCode"] == 404
 
         body = _parse_body(result)
-        assert "not found" in body["error"].lower()
+        assert "not found" in body["error"]["message"].lower()
 
     @patch("pricing_admin.handler.dynamodb")
     def test_get_ddb_error_returns_500(self, mock_ddb: Any) -> None:
@@ -277,7 +306,7 @@ class TestGetPrice:
 
         event = _make_event(method="GET", path="/pricing/anthropic/claude-sonnet-4")
         result = handler(event)
-        assert result["statusCode"] == 500
+        assert result["statusCode"] == 502
 
         body = _parse_body(result)
         assert "error" in body
@@ -377,7 +406,7 @@ class TestUpsertPrice:
         assert result["statusCode"] == 400
 
         body = _parse_body(result)
-        assert "invalid json" in body["error"].lower()
+        assert body["error"]["code"] == "validation_failed"
 
     def test_upsert_validation_error_negative_price(self) -> None:
         event = _make_event(
@@ -389,7 +418,7 @@ class TestUpsertPrice:
         assert result["statusCode"] == 400
 
         body = _parse_body(result)
-        assert "validation" in body["error"].lower()
+        assert body["error"]["code"] == "validation_failed"
 
     def test_upsert_missing_required_fields(self) -> None:
         event = _make_event(
@@ -401,7 +430,7 @@ class TestUpsertPrice:
         assert result["statusCode"] == 400
 
         body = _parse_body(result)
-        assert "validation" in body["error"].lower()
+        assert body["error"]["code"] == "validation_failed"
 
     def test_upsert_body_not_object(self) -> None:
         """Body is valid JSON but not an object (e.g. a list)."""
@@ -414,7 +443,7 @@ class TestUpsertPrice:
         assert result["statusCode"] == 400
 
         body = _parse_body(result)
-        assert "json object" in body["error"].lower()
+        assert body["error"]["code"] == "validation_failed"
 
     @patch("pricing_admin.handler.dynamodb")
     def test_upsert_ddb_error_returns_500(self, mock_ddb: Any) -> None:
@@ -431,7 +460,7 @@ class TestUpsertPrice:
             body={"input_per_1k": 0.003, "output_per_1k": 0.015},
         )
         result = handler(event)
-        assert result["statusCode"] == 500
+        assert result["statusCode"] == 502
 
         body = _parse_body(result)
         assert "error" in body
@@ -494,7 +523,7 @@ class TestDeletePrice:
         assert result["statusCode"] == 404
 
         body = _parse_body(result)
-        assert "not found" in body["error"].lower()
+        assert "not found" in body["error"]["message"].lower()
 
     @patch("pricing_admin.handler.dynamodb")
     def test_delete_ddb_error_returns_500(self, mock_ddb: Any) -> None:
@@ -507,7 +536,7 @@ class TestDeletePrice:
 
         event = _make_event(method="DELETE", path="/pricing/anthropic/claude-sonnet-4")
         result = handler(event)
-        assert result["statusCode"] == 500
+        assert result["statusCode"] == 502
 
         body = _parse_body(result)
         assert "error" in body
@@ -534,27 +563,27 @@ class TestUnsupportedMethod:
     def test_post_returns_405(self) -> None:
         event = _make_event(method="POST", path="/pricing/anthropic/claude-sonnet-4")
         result = handler(event)
-        assert result["statusCode"] == 405
+        assert result["statusCode"] == 404
 
         body = _parse_body(result)
-        assert "not allowed" in body["error"].lower()
+        assert "not found" in body["error"]["message"].lower()
 
     def test_patch_returns_405(self) -> None:
         event = _make_event(method="PATCH", path="/pricing/anthropic/claude-sonnet-4")
         result = handler(event)
-        assert result["statusCode"] == 405
+        assert result["statusCode"] == 404
 
     def test_put_without_provider_model_returns_405(self) -> None:
         """PUT /pricing (no provider/model) is not a valid route."""
         event = _make_event(method="PUT", path="/pricing")
         result = handler(event)
-        assert result["statusCode"] == 405
+        assert result["statusCode"] == 404
 
     def test_delete_without_provider_model_returns_405(self) -> None:
         """DELETE /pricing (no provider/model) is not a valid route."""
         event = _make_event(method="DELETE", path="/pricing")
         result = handler(event)
-        assert result["statusCode"] == 405
+        assert result["statusCode"] == 404
 
 
 # -- Response format -----------------------------------------------------------
@@ -603,7 +632,7 @@ class TestPathExtraction:
         """Path /pricing/anthropic (no model) should be 405 for non-GET."""
         event = _make_event(method="PUT", path="/pricing/anthropic")
         result = handler(event)
-        assert result["statusCode"] == 405
+        assert result["statusCode"] == 404
 
 
 # -- Base64 encoded body ------------------------------------------------------
@@ -623,6 +652,7 @@ class TestBase64Body:
             "requestContext": {"http": {"method": "PUT", "path": "/pricing/anthropic/claude-sonnet-4"}},
             "body": encoded,
             "isBase64Encoded": True,
+            "headers": {"authorization": f"Bearer {_ADMIN_JWT}"},
         }
         result = handler(event)
         assert result["statusCode"] == 200

--- a/tests/test_routing_config.py
+++ b/tests/test_routing_config.py
@@ -578,6 +578,102 @@ class TestHandlerMethodNotAllowed:
         assert result["statusCode"] == 404
 
 
+def _client_error(op: str = "GetItem") -> ClientError:
+    return ClientError({"Error": {"Code": "InternalServerError", "Message": "ddb down"}}, op)
+
+
+class TestHandlerStorageErrors:
+    """DynamoDB failures map to UpstreamError (502); the health route and the
+    outer catch-all (500) round out the error-branch coverage."""
+
+    def test_health_check(self) -> None:
+        event = _make_function_url_event("GET", "/health")
+        result = handler(event)
+        assert result["statusCode"] == 200
+        assert json.loads(result["body"])["status"] == "healthy"
+
+    @patch("routing_config.handler._get_custom_config")
+    @patch("routing_config.handler._get_builtin_configs")
+    def test_get_storage_error(self, mock_builtin: Any, mock_custom: Any) -> None:
+        mock_builtin.return_value = {}
+        mock_custom.side_effect = _client_error()
+        result = handler(_make_function_url_event("GET", "/routing/configs/x"))
+        assert result["statusCode"] == 502
+        assert json.loads(result["body"])["error"]["code"] == "upstream_error"
+
+    @patch("routing_config.handler._get_custom_config")
+    @patch("routing_config.handler._get_builtin_configs")
+    def test_create_conflict_check_storage_error(self, mock_builtin: Any, mock_custom: Any) -> None:
+        mock_builtin.return_value = {}
+        mock_custom.side_effect = _client_error()
+        body = {"name": "c", "strategy": {"mode": "fallback"}, "targets": [{"name": "t", "provider": "bedrock"}]}
+        result = handler(_make_function_url_event("POST", "/routing/configs", body))
+        assert result["statusCode"] == 502
+
+    @patch("routing_config.handler._put_custom_config")
+    @patch("routing_config.handler._get_custom_config")
+    @patch("routing_config.handler._get_builtin_configs")
+    def test_create_put_storage_error(self, mock_builtin: Any, mock_custom: Any, mock_put: Any) -> None:
+        mock_builtin.return_value = {}
+        mock_custom.return_value = None
+        mock_put.side_effect = _client_error("PutItem")
+        body = {"name": "c", "strategy": {"mode": "fallback"}, "targets": [{"name": "t", "provider": "bedrock"}]}
+        result = handler(_make_function_url_event("POST", "/routing/configs", body))
+        assert result["statusCode"] == 502
+
+    @patch("routing_config.handler._get_builtin_configs")
+    def test_update_invalid_config(self, mock_builtin: Any) -> None:
+        mock_builtin.return_value = {}
+        body = {"strategy": {"mode": "loadbalance"}, "targets": []}
+        result = handler(_make_function_url_event("PUT", "/routing/configs/x", body))
+        assert result["statusCode"] == 400
+        assert json.loads(result["body"])["error"]["code"] == "validation_failed"
+
+    @patch("routing_config.handler._get_custom_config")
+    @patch("routing_config.handler._get_builtin_configs")
+    def test_update_existence_check_storage_error(self, mock_builtin: Any, mock_custom: Any) -> None:
+        mock_builtin.return_value = {}
+        mock_custom.side_effect = _client_error()
+        body = {"strategy": {"mode": "fallback"}, "targets": [{"name": "t", "provider": "bedrock"}]}
+        result = handler(_make_function_url_event("PUT", "/routing/configs/x", body))
+        assert result["statusCode"] == 502
+
+    @patch("routing_config.handler._put_custom_config")
+    @patch("routing_config.handler._get_custom_config")
+    @patch("routing_config.handler._get_builtin_configs")
+    def test_update_put_storage_error(self, mock_builtin: Any, mock_custom: Any, mock_put: Any) -> None:
+        mock_builtin.return_value = {}
+        mock_custom.return_value = {"strategy": {"mode": "fallback"}}
+        mock_put.side_effect = _client_error("PutItem")
+        body = {"strategy": {"mode": "fallback"}, "targets": [{"name": "t", "provider": "bedrock"}]}
+        result = handler(_make_function_url_event("PUT", "/routing/configs/x", body))
+        assert result["statusCode"] == 502
+
+    @patch("routing_config.handler._delete_custom_config")
+    @patch("routing_config.handler._get_builtin_configs")
+    def test_delete_storage_error(self, mock_builtin: Any, mock_delete: Any) -> None:
+        mock_builtin.return_value = {}
+        mock_delete.side_effect = _client_error("DeleteItem")
+        result = handler(_make_function_url_event("DELETE", "/routing/configs/x"))
+        assert result["statusCode"] == 502
+
+    @patch("routing_config.handler._get_builtin_configs")
+    def test_create_body_not_object(self, mock_builtin: Any) -> None:
+        mock_builtin.return_value = {}
+        event = _make_function_url_event("POST", "/routing/configs")
+        event["body"] = "[1, 2, 3]"
+        result = handler(event)
+        assert result["statusCode"] == 400
+        assert json.loads(result["body"])["error"]["code"] == "validation_failed"
+
+    @patch("routing_config.handler._get_builtin_configs")
+    def test_unhandled_error_returns_500(self, mock_builtin: Any) -> None:
+        mock_builtin.side_effect = RuntimeError("boom")
+        result = handler(_make_function_url_event("GET", "/routing/configs"))
+        assert result["statusCode"] == 500
+        assert json.loads(result["body"])["error"]["code"] == "internal_error"
+
+
 # -- Property-based tests ------------------------------------------------------
 
 

--- a/tests/test_routing_config.py
+++ b/tests/test_routing_config.py
@@ -6,6 +6,7 @@ and handler routing for all HTTP methods.
 
 from __future__ import annotations
 
+import base64
 import json
 from pathlib import Path
 from typing import Any
@@ -18,10 +19,9 @@ from hypothesis import strategies as st
 from pydantic import ValidationError
 
 from routing_config.handler import (
-    _build_response,
-    _extract_config_name,
-    _extract_path_and_method,
+    _config_name,
     _load_builtin_configs,
+    _path_method,
     handler,
 )
 from routing_config.models import (
@@ -35,17 +35,30 @@ from routing_config.models import (
 
 # -- Helpers -------------------------------------------------------------------
 
+ADMIN_SCOPE = "https://gateway.internal/admin"
+
+
+def _make_jwt(claims: dict[str, Any]) -> str:
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).decode().rstrip("=")
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    return f"{header}.{payload}.sig"
+
+
+_ADMIN_JWT = _make_jwt({"sub": "admin-user", "scope": ADMIN_SCOPE})
+
 
 def _make_function_url_event(
     method: str = "GET",
     path: str = "/routing/configs",
     body: dict[str, Any] | None = None,
+    token: str | None = None,
 ) -> dict[str, Any]:
-    """Build a Lambda Function URL event."""
+    """Build an API Gateway event with an admin bearer by default."""
     event: dict[str, Any] = {
-        "requestContext": {"http": {"method": method, "path": path}},
+        "requestContext": {"requestId": "rid-test", "http": {"method": method, "path": path}},
         "rawPath": path,
         "isBase64Encoded": False,
+        "headers": {"authorization": f"Bearer {token or _ADMIN_JWT}"},
     }
     if body is not None:
         event["body"] = json.dumps(body)
@@ -221,45 +234,48 @@ class TestRoutingConfigSummary:
 class TestExtractPathAndMethod:
     def test_standard_event(self) -> None:
         event = _make_function_url_event("GET", "/routing/configs")
-        path, method = _extract_path_and_method(event)
+        path, method = _path_method(event)
         assert path == "/routing/configs"
         assert method == "GET"
 
     def test_with_config_name(self) -> None:
         event = _make_function_url_event("DELETE", "/routing/configs/my-config")
-        path, method = _extract_path_and_method(event)
+        path, method = _path_method(event)
         assert path == "/routing/configs/my-config"
         assert method == "DELETE"
 
     def test_missing_context_defaults(self) -> None:
-        _path, method = _extract_path_and_method({})
+        _path, method = _path_method({})
         assert method == "GET"
 
 
 class TestExtractConfigName:
     def test_list_path(self) -> None:
-        assert _extract_config_name("/routing/configs") is None
+        assert _config_name("/routing/configs") is None
 
     def test_named_path(self) -> None:
-        assert _extract_config_name("/routing/configs/cost-optimized") == "cost-optimized"
+        assert _config_name("/routing/configs/cost-optimized") == "cost-optimized"
 
     def test_trailing_slash(self) -> None:
-        assert _extract_config_name("/routing/configs/ab-test/") == "ab-test"
+        assert _config_name("/routing/configs/ab-test/") == "ab-test"
 
     def test_root_path(self) -> None:
-        assert _extract_config_name("/") is None
+        assert _config_name("/") is None
 
     def test_empty(self) -> None:
-        assert _extract_config_name("") is None
+        assert _config_name("") is None
 
 
-class TestBuildResponse:
-    def test_format(self) -> None:
-        resp = _build_response(200, {"ok": True})
-        assert resp["statusCode"] == 200
-        assert resp["headers"]["Content-Type"] == "application/json"
-        body = json.loads(resp["body"])
-        assert body["ok"] is True
+class TestAuthorization:
+    def test_missing_auth_401(self) -> None:
+        event = {"requestContext": {"http": {"method": "GET", "path": "/routing/configs"}}, "headers": {}}
+        assert handler(event)["statusCode"] == 401
+
+    def test_non_admin_403(self) -> None:
+        token = _make_jwt({"sub": "u", "scope": "https://gateway.internal/invoke"})
+        result = handler(_make_function_url_event("GET", "/routing/configs", token=token))
+        assert result["statusCode"] == 403
+        assert json.loads(result["body"])["error"]["code"] == "forbidden"
 
 
 # -- Built-in config loading ---------------------------------------------------
@@ -463,6 +479,7 @@ class TestHandlerCreateConfig:
     def test_create_invalid_json(self) -> None:
         event = {
             "requestContext": {"http": {"method": "POST", "path": "/routing/configs"}},
+            "headers": {"authorization": f"Bearer {_ADMIN_JWT}"},
             "rawPath": "/routing/configs",
             "body": "not-json!!!",
             "isBase64Encoded": False,
@@ -558,7 +575,7 @@ class TestHandlerMethodNotAllowed:
     def test_patch_not_allowed(self) -> None:
         event = _make_function_url_event("PATCH", "/routing/configs/test")
         result = handler(event)
-        assert result["statusCode"] == 405
+        assert result["statusCode"] == 404
 
 
 # -- Property-based tests ------------------------------------------------------
@@ -578,9 +595,9 @@ class TestPropertyBased:
 
     @given(path=st.text(max_size=200))
     @settings(max_examples=100, suppress_health_check=[HealthCheck.too_slow])
-    def test_extract_config_name_never_crashes(self, path: str) -> None:
+    def test_config_name_never_crashes(self, path: str) -> None:
         """Path extraction should never crash on any input."""
-        result = _extract_config_name(path)
+        result = _config_name(path)
         assert result is None or isinstance(result, str)
 
     @given(body_text=st.text(max_size=500))
@@ -589,6 +606,7 @@ class TestPropertyBased:
         """Handler should return a valid response for any body input."""
         event = {
             "requestContext": {"http": {"method": "POST", "path": "/routing/configs"}},
+            "headers": {"authorization": f"Bearer {_ADMIN_JWT}"},
             "rawPath": "/routing/configs",
             "body": body_text,
             "isBase64Encoded": False,

--- a/tests/test_usage_api.py
+++ b/tests/test_usage_api.py
@@ -1026,3 +1026,20 @@ class TestEnvConfiguration:
         from usage_api.handler import BUDGETS_TABLE
 
         assert isinstance(BUDGETS_TABLE, str)
+
+
+class TestHandlerInfra:
+    """Health route and the catch-all (non-ClientError → 500)."""
+
+    def test_health_check(self) -> None:
+        event = {"rawPath": "/health", "requestContext": {"http": {"method": "GET", "path": "/health"}}}
+        result = handler(event)
+        assert result["statusCode"] == 200
+        assert _parse_body(result)["status"] == "healthy"
+
+    @patch("usage_api.handler.dynamodb")
+    def test_unhandled_error_returns_500(self, mock_ddb: Any) -> None:
+        mock_ddb.Table.side_effect = RuntimeError("boom")
+        result = handler(_make_event(team="test-team"))
+        assert result["statusCode"] == 500
+        assert _err(result)["code"] == "internal_error"

--- a/tests/test_usage_api.py
+++ b/tests/test_usage_api.py
@@ -14,6 +14,7 @@ Covers:
 
 from __future__ import annotations
 
+import base64
 import json
 from decimal import Decimal
 from typing import Any
@@ -23,7 +24,6 @@ import pytest
 from botocore.exceptions import ClientError
 
 from usage_api.handler import (
-    _build_response,
     _current_period,
     _item_to_model_usage,
     _item_to_usage_period,
@@ -35,13 +35,29 @@ from usage_api.models import ModelUsage, UsagePeriod, UsageResponse
 
 # -- Helpers ------------------------------------------------------------------
 
+ADMIN_SCOPE = "https://gateway.internal/admin"
+INVOKE_SCOPE = "https://gateway.internal/invoke"
+
+
+def _make_jwt(claims: dict[str, Any]) -> str:
+    """Build a fake JWT (decoded, not verified) for the authorizer-context path."""
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).decode().rstrip("=")
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    return f"{header}.{payload}.sig"
+
+
+# Default caller: holds both invoke + admin scope, so existing tests that read
+# arbitrary teams still pass (admin bypasses tenant isolation).
+_ADMIN_JWT = _make_jwt({"sub": "admin-user", "scope": f"{INVOKE_SCOPE} {ADMIN_SCOPE}"})
+
 
 def _make_event(
     team: str | None = None,
     history: str | None = None,
     models: str | None = None,
+    token: str | None = None,
 ) -> dict[str, Any]:
-    """Build a Lambda Function URL event with query string parameters."""
+    """Build an API Gateway event with query params and an admin bearer by default."""
     params: dict[str, str] = {}
     if team is not None:
         params["team"] = team
@@ -51,8 +67,13 @@ def _make_event(
         params["models"] = models
     return {
         "queryStringParameters": params or None,
-        "requestContext": {"http": {"method": "GET", "path": "/usage"}},
+        "requestContext": {"requestId": "rid-test", "http": {"method": "GET", "path": "/usage"}},
+        "headers": {"authorization": f"Bearer {token or _ADMIN_JWT}"},
     }
+
+
+def _err(result: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(result["body"])["error"]
 
 
 def _make_usage_item(
@@ -312,19 +333,27 @@ class TestItemToModelUsage:
         assert _item_to_model_usage(item) is None
 
 
-class TestBuildResponse:
-    def test_format(self) -> None:
-        result = _build_response(200, {"ok": True})
-        assert result["statusCode"] == 200
-        assert result["headers"]["Content-Type"] == "application/json"
-        body = json.loads(result["body"])
-        assert body["ok"] is True
+# -- Authorization (now enforced via gwcore, ADR-016) -------------------------
 
-    def test_error_format(self) -> None:
-        result = _build_response(400, {"error": "bad request"})
-        assert result["statusCode"] == 400
-        body = json.loads(result["body"])
-        assert body["error"] == "bad request"
+
+class TestAuthorization:
+    def test_missing_auth_401(self) -> None:
+        event = {"queryStringParameters": {"team": "x"}, "requestContext": {"http": {"method": "GET"}}, "headers": {}}
+        assert handler(event)["statusCode"] == 401
+
+    def test_tenant_isolation_403(self) -> None:
+        # A non-admin caller scoped to team A cannot read team B's usage.
+        token = _make_jwt({"sub": "u", "scope": INVOKE_SCOPE, "custom:team": "team-a"})
+        result = handler(_make_event(team="team-b", token=token))
+        assert result["statusCode"] == 403
+        assert _err(result)["code"] == "forbidden"
+
+    @patch("usage_api.handler.dynamodb")
+    def test_own_team_allowed(self, mock_ddb: MagicMock) -> None:
+        mock_ddb.Table.return_value.get_item.return_value = {}
+        token = _make_jwt({"sub": "u", "scope": INVOKE_SCOPE, "custom:team": "team-a"})
+        result = handler(_make_event(team="team-a", token=token))
+        assert result["statusCode"] == 200
 
 
 # -- Handler: parameter validation --------------------------------------------
@@ -332,30 +361,28 @@ class TestBuildResponse:
 
 class TestHandlerParameterValidation:
     def test_missing_team_returns_400(self) -> None:
-        """Missing team parameter should return 400."""
-        event = _make_event()
-        result = handler(event)
+        """Missing team parameter should return 400 (after auth passes)."""
+        result = handler(_make_event())
         assert result["statusCode"] == 400
-        body = _parse_body(result)
-        assert "team" in body["error"].lower()
+        assert "team" in _err(result)["message"].lower()
 
     def test_empty_team_returns_400(self) -> None:
         """Empty team string should return 400."""
-        event = _make_event(team="")
-        result = handler(event)
-        assert result["statusCode"] == 400
+        assert handler(_make_event(team=""))["statusCode"] == 400
 
     def test_no_query_string_parameters_returns_400(self) -> None:
-        """Null queryStringParameters should return 400."""
-        event = {"queryStringParameters": None, "requestContext": {"http": {"method": "GET"}}}
-        result = handler(event)
-        assert result["statusCode"] == 400
+        """Null queryStringParameters should return 400 (admin caller)."""
+        event = {
+            "queryStringParameters": None,
+            "requestContext": {"http": {"method": "GET"}},
+            "headers": {"authorization": f"Bearer {_ADMIN_JWT}"},
+        }
+        assert handler(event)["statusCode"] == 400
 
     def test_missing_query_string_key_returns_400(self) -> None:
         """Missing queryStringParameters key entirely should return 400."""
-        event = {"requestContext": {"http": {"method": "GET"}}}
-        result = handler(event)
-        assert result["statusCode"] == 400
+        event = {"requestContext": {"http": {"method": "GET"}}, "headers": {"authorization": f"Bearer {_ADMIN_JWT}"}}
+        assert handler(event)["statusCode"] == 400
 
     @patch("usage_api.handler.dynamodb")
     def test_invalid_history_defaults_to_zero(self, mock_ddb: Any) -> None:
@@ -893,8 +920,8 @@ class TestHandlerDDBErrors:
         assert result["statusCode"] == 502
 
     @patch("usage_api.handler.dynamodb")
-    def test_generic_exception_current_usage_returns_502(self, mock_ddb: Any) -> None:
-        """Generic exception during current usage query should return 502."""
+    def test_generic_exception_current_usage_returns_500(self, mock_ddb: Any) -> None:
+        """A non-ClientError (unexpected) maps to 500 internal_error, not 502 upstream."""
         mock_table = MagicMock()
         mock_table.get_item.side_effect = RuntimeError("unexpected")
         mock_ddb.Table.return_value = mock_table
@@ -902,7 +929,7 @@ class TestHandlerDDBErrors:
         event = _make_event(team="test-team")
         result = handler(event)
 
-        assert result["statusCode"] == 502
+        assert result["statusCode"] == 500
 
 
 # -- Handler: combined scenarios ----------------------------------------------

--- a/tests/test_usage_api.py
+++ b/tests/test_usage_api.py
@@ -355,6 +355,14 @@ class TestAuthorization:
         result = handler(_make_event(team="team-a", token=token))
         assert result["statusCode"] == 200
 
+    def test_empty_team_claim_cannot_read_arbitrary_team(self) -> None:
+        # A non-admin whose token carries NO team claim must not read another
+        # team via ?team= — an empty claim must not bypass tenant isolation.
+        token = _make_jwt({"sub": "u", "scope": INVOKE_SCOPE})
+        result = handler(_make_event(team="team-b", token=token))
+        assert result["statusCode"] == 403
+        assert _err(result)["code"] == "forbidden"
+
 
 # -- Handler: parameter validation --------------------------------------------
 


### PR DESCRIPTION
## Summary

Third batch onto the `gwcore` foundation (ADR-016) — the read/CRUD HTTP trio. **None of these had any in-handler authorization before**; all relied solely on the API Gateway authorizer with no defense in depth.

### usage_api — closes a tenant-isolation gap
Labeled "self-service" but read **any** team's usage/spend from the `?team=` query param with no ownership check. Now: requires the invoke scope, and a non-admin caller may read only their **own** team (`principal.team == requested team`); admin bypasses.

### pricing_admin — admin CRUD, now authorized + audited
Requires admin scope. `pricing.upsert` / `pricing.delete` emit audit events. DynamoDB failures map to `UpstreamError` (502) instead of hand-rolled 500s.

### routing_config — admin CRUD, now authorized + audited
Requires admin scope. `routing.create` / `.update` / `.delete` emit audit events.

### Common to all three
gwcore response envelope + typed errors, `gwcore.request_body()` base64 decode, structured logging + EMF metrics, and a denial audit event on 401/403.

## Test plan
- `uv run pytest tests/` — **616 passing** (usage 99% / pricing / routing 79–88% coverage).
- Tests rewritten to the gwcore contract: authz enforcement (401/403), tenant isolation (usage), the new error envelope, 502-on-upstream-failure.
- `ruff check .` + `ruff format --check .` — clean. `pyright src/` — **0 errors**. `semgrep` — 0 findings.

No Terraform changes (pure Python).

## Follow-ups
6 services remain on gwcore: the request-path / enforcement Lambdas (budget_enforcement, rate_limiter, content_scanner, pre_token, cost_attribution) handled individually, plus chargeback_report (Step-Functions-invoked, lighter touch).

🤖 Generated with Bonk
