### PR TITLE
refactor: migrate budget_enforcement onto gwcore observability

### DIFF
--- a/src/budget_enforcement/handler.py
+++ b/src/budget_enforcement/handler.py
@@ -1,17 +1,23 @@
 """Pre-request budget enforcement Lambda (Function URL).
 
-Called by the gateway before forwarding a request to the upstream LLM.
-Returns 200 with ``{"allowed": true}`` if the team/user is within budget,
-or 429 with a rich error body if the budget is exceeded.
+A Portkey plugin webhook: the gateway calls it before forwarding a request to
+the upstream LLM. It ALWAYS returns HTTP 200 with a ``verdict`` field — the
+verdict (true/false) carries the allow/deny decision, because a 4xx would be
+treated by Portkey as a hook *failure*, not a deny.
 
-Graceful degradation: if DynamoDB is unreachable the request is allowed
-and a warning is logged.
+Graceful degradation: if DynamoDB is unreachable the request is allowed and a
+warning is logged — a budget-check outage must never block traffic.
+
+Migrated onto gwcore (ADR-016): structured JSON logging with a correlation id,
+a latency Timer, deny metrics, and a deny-audit event on every block. The
+response contract and degradation behavior are unchanged. The JWT arrives in
+the request *body* (ALB pre-verifies its signature), so this handler does no
+in-handler authorization — ``gwcore.auth`` (header-based) does not apply here.
 """
 
 from __future__ import annotations
 
 import json
-import logging
 import os
 from calendar import monthrange
 from datetime import UTC, datetime
@@ -37,25 +43,12 @@ from budget_enforcement.models import (
     ModelLimit,
     TierConfig,
 )
+from gwcore import audit
+from gwcore.logging import bind, correlation_id, get_logger
+from gwcore.telemetry import Timer, emit_metric
 from rate_limiter.handler import check_rate_limit
 
-logger = logging.getLogger("budget_enforcement")
-logger.setLevel(logging.INFO)
-if not logger.handlers:
-    _h = logging.StreamHandler()
-    _h.setFormatter(
-        logging.Formatter(
-            json.dumps(
-                {
-                    "timestamp": "%(asctime)s",
-                    "level": "%(levelname)s",
-                    "logger": "%(name)s",
-                    "message": "%(message)s",
-                }
-            )
-        )
-    )
-    logger.addHandler(_h)
+logger = get_logger("budget_enforcement")
 
 BUDGETS_TABLE = os.environ.get("BUDGETS_TABLE", "gateway-budgets")
 USAGE_TABLE = os.environ.get("USAGE_TABLE", "gateway-usage")
@@ -356,41 +349,68 @@ def _check_budget(request: BudgetCheckRequest) -> BudgetCheckResponse:
 # ── Lambda entry point (Function URL) ────────────────────────────────────────
 
 
+def _audit_denial(event: dict[str, Any], request: BudgetCheckRequest, result: BudgetCheckResponse) -> None:
+    """Emit a deny metric + audit event for a blocked request (best-effort).
+
+    Only fires on a hard deny (``verdict`` false). Graceful-degradation allows
+    and warning-threshold allows are not denials, so they are not audited here.
+    """
+    if result.allowed:
+        return
+    claims = decode_jwt_payload(request.jwt_token)
+    team = extract_team(claims)
+    actor = extract_user(claims)
+    emit_metric("BudgetDenied", 1, dimensions={"Route": "budget_enforcement"})
+    audit.emit(
+        audit.event_from_request(
+            event,
+            action="budget.enforce",
+            actor=actor,
+            resource=request.model,
+            decision="deny",
+            status=result.status_code,
+            team=team,
+            detail=result.reason,
+        )
+    )
+
+
 def handler(event: dict[str, Any], _context: Any = None) -> dict[str, Any]:
     """Lambda Function URL handler.
 
     Expects a JSON body with ``jwt_token`` (and optionally ``model``,
     ``provider``, ``estimated_tokens``).
     """
-    try:
-        body_str = event.get("body", "{}")
-        if event.get("isBase64Encoded"):
-            import base64  # noqa: PLC0415
+    cid = correlation_id(event)
+    log = bind(logger, cid)
 
-            body_str = base64.b64decode(body_str).decode()
-        body = json.loads(body_str) if isinstance(body_str, str) else body_str
-    except (json.JSONDecodeError, Exception):
-        logger.exception("Failed to parse request body")
-        resp = BudgetCheckResponse(
-            allowed=False,
-            status_code=400,
-            reason="Invalid request body",
-        )
-        return _build_response(resp)
+    with Timer("RequestLatency", route="budget_enforcement"):
+        try:
+            body_str = event.get("body", "{}")
+            if event.get("isBase64Encoded"):
+                import base64  # noqa: PLC0415
 
-    try:
-        request = BudgetCheckRequest.model_validate(body)
-    except ValidationError as e:
-        logger.warning("Invalid budget check request: %s", e)
-        resp = BudgetCheckResponse(
-            allowed=False,
-            status_code=400,
-            reason=f"Validation error: {e.error_count()} errors",
-        )
-        return _build_response(resp)
+                body_str = base64.b64decode(body_str).decode()
+            body = json.loads(body_str) if isinstance(body_str, str) else body_str
+        except (json.JSONDecodeError, Exception):
+            log.exception("Failed to parse request body")
+            emit_metric("BudgetEnforcementError", 1, dimensions={"Code": "bad_request"})
+            resp = BudgetCheckResponse(allowed=False, status_code=400, reason="Invalid request body")
+            return _build_response(resp)
 
-    result = _check_budget(request)
-    return _build_response(result)
+        try:
+            request = BudgetCheckRequest.model_validate(body)
+        except ValidationError as e:
+            log.warning("Invalid budget check request: %s", e)
+            emit_metric("BudgetEnforcementError", 1, dimensions={"Code": "validation_error"})
+            resp = BudgetCheckResponse(
+                allowed=False, status_code=400, reason=f"Validation error: {e.error_count()} errors"
+            )
+            return _build_response(resp)
+
+        result = _check_budget(request)
+        _audit_denial(event, request, result)
+        return _build_response(result)
 
 
 def _build_response(result: BudgetCheckResponse) -> dict[str, Any]:

--- a/tests/test_budget_enforcement.py
+++ b/tests/test_budget_enforcement.py
@@ -647,6 +647,93 @@ class TestBudgetHandler:
         assert "budget_status" in body["data"]
 
 
+# ── gwcore observability (ADR-016) ───────────────────────────────────────────
+
+
+class TestObservability:
+    """The migration adds a deny-audit + metrics without changing the contract."""
+
+    @patch("budget_enforcement.handler.audit.emit")
+    @patch("budget_enforcement.handler.emit_metric")
+    @patch("budget_enforcement.handler._get_current_usage")
+    @patch("budget_enforcement.handler._get_budget_record")
+    def test_deny_emits_audit_and_metric(
+        self, mock_budget: Any, mock_usage: Any, mock_metric: Any, mock_audit: Any
+    ) -> None:
+        mock_budget.return_value = {"monthly_budget_usd": "100", "warn_threshold_pct": 80, "hard_limit_pct": 100}
+        mock_usage.return_value = Decimal("150.00")
+
+        jwt = _make_jwt({"custom:team": "platform", "sub": "user1"})
+        result = handler(_make_function_url_event({"jwt_token": jwt}))
+
+        assert json.loads(result["body"])["verdict"] is False
+        # A deny audit event was emitted with decision="deny" and the team.
+        assert mock_audit.call_count == 1
+        emitted = mock_audit.call_args.args[0]
+        assert emitted.decision == "deny"
+        assert emitted.team == "platform"
+        assert emitted.actor == "user1"
+        # The BudgetDenied metric fired.
+        assert any(c.args and c.args[0] == "BudgetDenied" for c in mock_metric.call_args_list)
+
+    @patch("budget_enforcement.handler.audit.emit")
+    @patch("budget_enforcement.handler._get_current_usage")
+    @patch("budget_enforcement.handler._get_budget_record")
+    def test_allow_does_not_audit(self, mock_budget: Any, mock_usage: Any, mock_audit: Any) -> None:
+        mock_budget.return_value = {"monthly_budget_usd": "1000", "warn_threshold_pct": 80, "hard_limit_pct": 100}
+        mock_usage.return_value = Decimal("50.00")
+
+        jwt = _make_jwt({"custom:team": "platform", "sub": "user1"})
+        result = handler(_make_function_url_event({"jwt_token": jwt}))
+
+        assert json.loads(result["body"])["verdict"] is True
+        mock_audit.assert_not_called()
+
+    @patch("budget_enforcement.handler.emit_metric")
+    def test_invalid_body_emits_error_metric(self, mock_metric: Any) -> None:
+        result = handler({"body": "not json!!!", "isBase64Encoded": False})
+        assert json.loads(result["body"])["verdict"] is False
+        assert any(c.args and c.args[0] == "BudgetEnforcementError" for c in mock_metric.call_args_list)
+
+    @patch("budget_enforcement.handler.emit_metric")
+    def test_validation_error_emits_error_metric(self, mock_metric: Any) -> None:
+        result = handler(_make_function_url_event({"model": "gpt-4"}))
+        assert json.loads(result["body"])["verdict"] is False
+        assert any(c.args and c.args[0] == "BudgetEnforcementError" for c in mock_metric.call_args_list)
+
+    @patch("budget_enforcement.handler.audit.emit")
+    @patch("budget_enforcement.handler.check_rate_limit")
+    @patch("budget_enforcement.handler._get_budget_record")
+    def test_rate_limit_deny_audited(self, mock_budget: Any, mock_rate: Any, mock_audit: Any) -> None:
+        from rate_limiter.models import RateLimitResult
+
+        mock_budget.return_value = {"monthly_budget_usd": "1000", "warn_threshold_pct": 80, "hard_limit_pct": 100}
+        mock_rate.return_value = RateLimitResult(allowed=False, reason="RPM exceeded", retry_after_seconds=42)
+
+        jwt = _make_jwt({"custom:team": "platform", "sub": "user1"})
+        result = handler(_make_function_url_event({"jwt_token": jwt}))
+
+        body = json.loads(result["body"])
+        assert body["verdict"] is False
+        assert body["data"]["retry_after_seconds"] == 42
+        assert mock_audit.call_args.args[0].decision == "deny"
+
+    @patch("budget_enforcement.handler._get_current_usage")
+    @patch("budget_enforcement.handler._get_budget_record")
+    def test_malformed_monthly_budget_falls_back(self, mock_budget: Any, mock_usage: Any) -> None:
+        # A non-numeric monthly_budget_usd must fall back to the $1000 default,
+        # not crash the check.
+        mock_budget.return_value = {"monthly_budget_usd": "not-a-number", "warn_threshold_pct": 80}
+        mock_usage.return_value = Decimal("10.00")
+
+        jwt = _make_jwt({"custom:team": "platform", "sub": "user1"})
+        result = handler(_make_function_url_event({"jwt_token": jwt}))
+
+        body = json.loads(result["body"])
+        assert body["verdict"] is True
+        assert body["data"]["budget_status"]["monthly_budget_usd"] == "1000"
+
+
 # ── Seconds until period reset ───────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What

Migrates **budget_enforcement** — the pre-request budget/rate gate Portkey calls before forwarding to the upstream LLM — onto the shared `gwcore` foundation (ADR-016). This is the first of the enforcement Lambdas, handled individually (per the agreed cadence) because of its latency sensitivity and load-bearing contract.

## Contract preserved (unchanged)

- **Always HTTP 200 with a `verdict` field.** A 4xx is treated by Portkey as a hook *failure*, not a deny — so the allow/deny decision rides in `verdict`, not the status code.
- **JWT in the request body.** ALB pre-verifies the signature upstream; this Lambda only decodes claims. It performs **no in-handler authorization**, so the header-based `gwcore.auth` does not apply here.
- **Graceful degradation.** DynamoDB unreachable → allow + warning. A budget-check outage must never block traffic.

## What changed (lighter-touch observability migration)

- Bespoke JSON logger → `gwcore.logging` (correlation id bound per request; one log shape across the plane).
- `RequestLatency` Timer around the handler; `BudgetEnforcementError` metric on bad-request / validation failures.
- `BudgetDenied` metric + **deny-audit event** on every hard block (budget, model-budget, or rate-limit deny), for forensic parity with the CRUD services. Allows and graceful-degradation allows are not audited.

## Tests

- New `TestObservability`: deny emits audit + metric, allow does not, bad-request/validation emit the error metric.
- Added coverage for the pre-existing rate-limit-deny and malformed-`monthly_budget_usd` fallback branches.
- Handler at 87% (remaining misses are boto3 DDB wrappers mocked in every test). **637 passing**, ruff clean, pyright 0/0/0, semgrep clean.