### PR TITLE
refactor: migrate rate_limiter onto gwcore observability

### DIFF
--- a/src/rate_limiter/handler.py
+++ b/src/rate_limiter/handler.py
@@ -1,41 +1,35 @@
 """Rate limiting enforcement using DynamoDB atomic counters.
 
-Provides RPM (requests-per-minute) and daily token limit checks.
+Provides RPM (requests-per-minute) and daily token limit checks via the
+``check_rate_limit`` library function. This is a pure module — it has no Lambda
+handler, no request event, and performs no authorization; ``budget_enforcement``
+(the pre-request webhook) imports and calls it on the hot path, and that caller
+emits the deny-audit. So this module emits metrics and structured logs only,
+never an audit event (which would double-count the same denial).
+
 Uses the same usage table as budget enforcement with different PK prefixes.
 
-Graceful degradation: if DynamoDB is unreachable the request is allowed
-and a warning is logged.
+Graceful degradation: if DynamoDB is unreachable the request is allowed and a
+warning is logged — a rate-limit-store outage must never block traffic.
+
+Migrated onto gwcore (ADR-016): structured JSON logging + denial/degraded
+metrics. The ``check_rate_limit`` contract and degradation behavior are
+unchanged.
 """
 
 from __future__ import annotations
 
-import json
-import logging
 import os
 from datetime import UTC, datetime
 
 import boto3
 from botocore.exceptions import ClientError
 
+from gwcore.logging import get_logger
+from gwcore.telemetry import emit_metric
 from rate_limiter.models import RateLimitResult
 
-logger = logging.getLogger("rate_limiter")
-logger.setLevel(logging.INFO)
-if not logger.handlers:
-    _h = logging.StreamHandler()
-    _h.setFormatter(
-        logging.Formatter(
-            json.dumps(
-                {
-                    "timestamp": "%(asctime)s",
-                    "level": "%(levelname)s",
-                    "logger": "%(name)s",
-                    "message": "%(message)s",
-                }
-            )
-        )
-    )
-    logger.addHandler(_h)
+logger = get_logger("rate_limiter")
 
 USAGE_TABLE = os.environ.get("USAGE_TABLE", "gateway-usage")
 
@@ -173,6 +167,7 @@ def check_rate_limit(
                 team,
                 exc_info=True,
             )
+            emit_metric("RateLimitDegraded", 1, dimensions={"Check": "rpm"})
             return RateLimitResult(allowed=True, reason="rate-limit-degraded")
 
         if current_rpm > rpm_limit:
@@ -182,6 +177,7 @@ def check_rate_limit(
                 current_rpm,
                 rpm_limit,
             )
+            emit_metric("RateLimitDenied", 1, dimensions={"Check": "rpm"})
             return RateLimitResult(
                 allowed=False,
                 reason=f"RPM limit exceeded ({current_rpm}/{rpm_limit} requests per minute)",
@@ -200,6 +196,7 @@ def check_rate_limit(
                 team,
                 exc_info=True,
             )
+            emit_metric("RateLimitDegraded", 1, dimensions={"Check": "daily_tokens"})
             return RateLimitResult(
                 allowed=True,
                 reason="rate-limit-degraded",
@@ -213,6 +210,7 @@ def check_rate_limit(
                 current_daily_tokens,
                 tokens_per_day_limit,
             )
+            emit_metric("RateLimitDenied", 1, dimensions={"Check": "daily_tokens"})
             return RateLimitResult(
                 allowed=False,
                 reason=f"Daily token limit exceeded ({current_daily_tokens:,}/{tokens_per_day_limit:,} tokens per day)",

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -278,3 +278,50 @@ class TestCombinedScenarios:
         assert "Daily token limit exceeded" in result.reason
         assert result.current_rpm == 5
         assert result.current_daily_tokens == 2000000
+
+
+def _emitted(mock_metric: Any, name: str, dimensions: dict[str, str] | None = None) -> bool:
+    """True if emit_metric was called with the given name (and dimensions, if given)."""
+    for c in mock_metric.call_args_list:
+        if c.args and c.args[0] == name and (dimensions is None or c.kwargs.get("dimensions") == dimensions):
+            return True
+    return False
+
+
+class TestMetrics:
+    """gwcore migration (ADR-016): deny + degraded emit EMF metrics. No audit
+    event is emitted here — the budget_enforcement caller audits the denial."""
+
+    @patch("rate_limiter.handler.emit_metric")
+    @patch("rate_limiter.handler._increment_rpm_counter")
+    def test_rpm_deny_emits_metric(self, mock_rpm: Any, mock_metric: Any) -> None:
+        mock_rpm.return_value = 101
+        result = check_rate_limit(team="t", rpm_limit=100, tokens_per_day_limit=-1)
+        assert result.allowed is False
+        assert _emitted(mock_metric, "RateLimitDenied", {"Check": "rpm"})
+
+    @patch("rate_limiter.handler.emit_metric")
+    @patch("rate_limiter.handler._increment_rpm_counter")
+    def test_rpm_degraded_emits_metric(self, mock_rpm: Any, mock_metric: Any) -> None:
+        mock_rpm.side_effect = RuntimeError("ddb down")
+        result = check_rate_limit(team="t", rpm_limit=100, tokens_per_day_limit=-1)
+        assert result.allowed is True
+        assert _emitted(mock_metric, "RateLimitDegraded")
+
+    @patch("rate_limiter.handler.emit_metric")
+    @patch("rate_limiter.handler._increment_daily_token_counter")
+    @patch("rate_limiter.handler._increment_rpm_counter")
+    def test_daily_token_deny_emits_metric(self, mock_rpm: Any, mock_tokens: Any, mock_metric: Any) -> None:
+        mock_rpm.return_value = 1
+        mock_tokens.return_value = 2_000_000
+        result = check_rate_limit(team="t", rpm_limit=100, tokens_per_day_limit=1_000_000, estimated_tokens=10)
+        assert result.allowed is False
+        assert _emitted(mock_metric, "RateLimitDenied", {"Check": "daily_tokens"})
+
+    @patch("rate_limiter.handler.emit_metric")
+    @patch("rate_limiter.handler._increment_rpm_counter")
+    def test_allowed_emits_no_metric(self, mock_rpm: Any, mock_metric: Any) -> None:
+        mock_rpm.return_value = 5
+        result = check_rate_limit(team="t", rpm_limit=100, tokens_per_day_limit=-1)
+        assert result.allowed is True
+        mock_metric.assert_not_called()

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -306,7 +306,17 @@ class TestMetrics:
         mock_rpm.side_effect = RuntimeError("ddb down")
         result = check_rate_limit(team="t", rpm_limit=100, tokens_per_day_limit=-1)
         assert result.allowed is True
-        assert _emitted(mock_metric, "RateLimitDegraded")
+        assert _emitted(mock_metric, "RateLimitDegraded", {"Check": "rpm"})
+
+    @patch("rate_limiter.handler.emit_metric")
+    @patch("rate_limiter.handler._increment_daily_token_counter")
+    @patch("rate_limiter.handler._increment_rpm_counter")
+    def test_daily_token_degraded_emits_metric(self, mock_rpm: Any, mock_tokens: Any, mock_metric: Any) -> None:
+        mock_rpm.return_value = 1
+        mock_tokens.side_effect = RuntimeError("ddb down")
+        result = check_rate_limit(team="t", rpm_limit=100, tokens_per_day_limit=1_000_000, estimated_tokens=10)
+        assert result.allowed is True
+        assert _emitted(mock_metric, "RateLimitDegraded", {"Check": "daily_tokens"})
 
     @patch("rate_limiter.handler.emit_metric")
     @patch("rate_limiter.handler._increment_daily_token_counter")


### PR DESCRIPTION
## What

Migrates **rate_limiter** onto the shared `gwcore` foundation (ADR-016). Second of the enforcement Lambdas.

`rate_limiter` is a **pure library module** — `check_rate_limit(team, rpm_limit, tokens_per_day_limit, estimated_tokens)` backed by DynamoDB atomic counters (RPM sliding-window + daily-token). It has **no Lambda handler, no request event, and no authorization**. `budget_enforcement` (the pre-request webhook, migrated in #222) imports and calls it on the hot path.

## Why metrics-only (no audit)

`budget_enforcement._audit_denial` already emits the deny-audit when a rate-limit check blocks a request. Emitting an audit event here too would **double-count the same denial**. So this migration adds metrics + structured logging only.

## What changed

- Bespoke JSON logger → `gwcore.logging`.
- `RateLimitDenied` / `RateLimitDegraded` EMF metrics at each deny + graceful-degradation point, dimensioned by `Check` (`rpm` | `daily_tokens`).
- `check_rate_limit` contract and DDB-unreachable → allow degradation are **unchanged**.

## Tests

- New `TestMetrics`: deny and degraded paths emit the right metric + dimensions; an allow emits none.
- **641 passing**, ruff clean, pyright 0/0/0, semgrep clean. (Handler line coverage is the pre-existing 79% — the uncovered lines are the boto3 atomic-counter helpers mocked in every test; my changed lines are all covered.)