### PR TITLE
refactor: migrate cost_attribution onto gwcore observability

### DIFF
--- a/src/cost_attribution/handler.py
+++ b/src/cost_attribution/handler.py
@@ -1,11 +1,24 @@
-"""Lambda handler for AI Gateway cost attribution."""
+"""Lambda handler for AI Gateway cost attribution.
+
+A CloudWatch Logs subscription Lambda: it parses gateway access logs, derives
+per-request cost/token metrics, publishes them as *billing* CloudWatch metrics
+(rich Provider/Model/Team dimensions), accumulates usage in DynamoDB, fires SNS
+budget alerts, and writes usage records to the audit Firehose. It is event-
+driven (no HTTP, no Portkey contract) and does no authorization.
+
+Migrated onto gwcore (ADR-016) for the lightest touch: structured JSON logging
+plus operational EMF metrics for handler outcomes (decode failures, processed /
+error counts, metric-publish failures). The existing *billing* CloudWatch
+metrics and the usage Firehose records are domain telemetry with their own
+Iceberg schema and are deliberately left as-is — gwcore observability
+complements them, it does not replace them.
+"""
 
 from __future__ import annotations
 
 import base64
 import gzip
 import json
-import logging
 import os
 import uuid
 from datetime import UTC, datetime
@@ -18,24 +31,10 @@ from pydantic import ValidationError
 
 from cost_attribution.models import HandlerResponse, LogRecord, MetricResult
 from cost_attribution.pricing import get_cost, is_known_model
+from gwcore.logging import get_logger
+from gwcore.telemetry import Timer, emit_metric
 
-logger = logging.getLogger("cost_attribution")
-logger.setLevel(logging.INFO)
-if not logger.handlers:
-    _h = logging.StreamHandler()
-    _h.setFormatter(
-        logging.Formatter(
-            json.dumps(
-                {
-                    "timestamp": "%(asctime)s",
-                    "level": "%(levelname)s",
-                    "logger": "%(name)s",
-                    "message": "%(message)s",
-                }
-            )
-        )
-    )
-    logger.addHandler(_h)
+logger = get_logger("cost_attribution")
 
 METRIC_NAMESPACE = os.environ.get("METRIC_NAMESPACE", "AIGateway")
 USAGE_TABLE = os.environ.get("USAGE_TABLE", "gateway-usage")
@@ -557,10 +556,16 @@ def _publish_audit_records(metrics: list[MetricResult]) -> None:
 
 
 def handler(event: dict[str, Any], _context: Any = None) -> dict[str, Any]:
+    with Timer("RequestLatency", route="cost_attribution"):
+        return _handle(event)
+
+
+def _handle(event: dict[str, Any]) -> dict[str, Any]:
     try:
         log_data = _decode_log_data(event)
     except Exception:
         logger.exception("Failed to decode log event payload")
+        emit_metric("CostAttributionError", 1, dimensions={"Code": "decode_error"})
         return HandlerResponse(statusCode=400, error="Failed to decode log data").model_dump(exclude_none=True)
 
     log_events = log_data.get("logEvents", [])
@@ -577,11 +582,16 @@ def handler(event: dict[str, Any], _context: Any = None) -> dict[str, Any]:
             logger.exception("Failed to process log event: %s", log_event.get("id", "unknown"))
             errors += 1
 
+    emit_metric("EventsProcessed", float(len(extracted)), dimensions={"Route": "cost_attribution"})
+    if errors:
+        emit_metric("CostAttributionError", float(errors), dimensions={"Code": "extract_error"})
+
     if extracted:
         try:
             _publish_metrics(extracted)
         except Exception:
             logger.exception("Failed to publish metrics to CloudWatch")
+            emit_metric("CostAttributionError", 1, dimensions={"Code": "publish_error"})
             return HandlerResponse(
                 statusCode=500, processed=len(extracted), errors=errors, error="Failed to publish metrics"
             ).model_dump(exclude_none=True)

--- a/tests/test_cost_attribution.py
+++ b/tests/test_cost_attribution.py
@@ -1036,9 +1036,7 @@ class TestObservability:
     @patch("cost_attribution.handler.check_and_publish_alerts")
     @patch("cost_attribution.handler.dynamodb")
     @patch("cost_attribution.handler.cloudwatch")
-    def test_processed_metric_emitted(
-        self, mock_cw: Any, mock_ddb: Any, mock_alerts: Any, mock_metric: Any
-    ) -> None:
+    def test_processed_metric_emitted(self, mock_cw: Any, mock_ddb: Any, mock_alerts: Any, mock_metric: Any) -> None:
         mock_alerts.return_value = 0
         log_events = [
             {

--- a/tests/test_cost_attribution.py
+++ b/tests/test_cost_attribution.py
@@ -1023,3 +1023,86 @@ class TestPerTeamCacheMetrics:
         assert savings_by_team[0]["Dimensions"] == [{"Name": "Team", "Value": "data-eng"}]
         assert savings_by_team[0]["Value"] == 0.005
         assert savings_by_team[0]["Unit"] == "None"
+
+
+# ── gwcore observability (ADR-016) ───────────────────────────────────────────
+
+
+class TestObservability:
+    """The migration adds operational EMF metrics for handler outcomes. The
+    billing CloudWatch metrics and usage Firehose records are unchanged."""
+
+    @patch("cost_attribution.handler.emit_metric")
+    @patch("cost_attribution.handler.check_and_publish_alerts")
+    @patch("cost_attribution.handler.dynamodb")
+    @patch("cost_attribution.handler.cloudwatch")
+    def test_processed_metric_emitted(
+        self, mock_cw: Any, mock_ddb: Any, mock_alerts: Any, mock_metric: Any
+    ) -> None:
+        mock_alerts.return_value = 0
+        log_events = [
+            {
+                "id": "1",
+                "message": json.dumps(
+                    {
+                        "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+                        "model": "gpt-4",
+                        "req": {"headers": {"x-portkey-provider": "openai"}},
+                    }
+                ),
+            }
+        ]
+        handler(_make_event(log_events))
+        assert any(c.args and c.args[0] == "EventsProcessed" and c.args[1] == 1.0 for c in mock_metric.call_args_list)
+
+    @patch("cost_attribution.handler.emit_metric")
+    def test_decode_error_metric_emitted(self, mock_metric: Any) -> None:
+        result = handler({"awslogs": {"data": "not-valid-base64!!!"}})
+        assert result["statusCode"] == 400
+        assert any(
+            c.args and c.args[0] == "CostAttributionError" and c.kwargs.get("dimensions") == {"Code": "decode_error"}
+            for c in mock_metric.call_args_list
+        )
+
+    @patch("cost_attribution.handler.emit_metric")
+    @patch("cost_attribution.handler.check_and_publish_alerts")
+    @patch("cost_attribution.handler.dynamodb")
+    @patch("cost_attribution.handler.cloudwatch")
+    def test_extract_error_metric_emitted(
+        self, mock_cw: Any, mock_ddb: Any, mock_alerts: Any, mock_metric: Any
+    ) -> None:
+        mock_alerts.return_value = 0
+        # A log event whose message is valid JSON but processing raises -> error.
+        with patch("cost_attribution.handler._extract_metrics", side_effect=RuntimeError("boom")):
+            handler(_make_event([{"id": "1", "message": "{}"}]))
+        assert any(
+            c.args and c.args[0] == "CostAttributionError" and c.kwargs.get("dimensions") == {"Code": "extract_error"}
+            for c in mock_metric.call_args_list
+        )
+
+    @patch("cost_attribution.handler.emit_metric")
+    @patch("cost_attribution.handler.check_and_publish_alerts")
+    @patch("cost_attribution.handler.dynamodb")
+    @patch("cost_attribution.handler.cloudwatch")
+    def test_publish_error_metric_emitted(
+        self, mock_cw: Any, mock_ddb: Any, mock_alerts: Any, mock_metric: Any
+    ) -> None:
+        mock_alerts.return_value = 0
+        mock_cw.put_metric_data.side_effect = Exception("cw down")
+        log_events = [
+            {
+                "id": "1",
+                "message": json.dumps(
+                    {
+                        "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+                        "model": "gpt-4",
+                    }
+                ),
+            }
+        ]
+        result = handler(_make_event(log_events))
+        assert result["statusCode"] == 500
+        assert any(
+            c.args and c.args[0] == "CostAttributionError" and c.kwargs.get("dimensions") == {"Code": "publish_error"}
+            for c in mock_metric.call_args_list
+        )


### PR DESCRIPTION
## What

Migrates **cost_attribution** onto `gwcore` (ADR-016). Fifth enforcement/processing Lambda.

`cost_attribution` is a **CloudWatch Logs subscription** Lambda: it parses gateway access logs into per-request cost/token metrics, publishes them as **billing** CloudWatch metrics (rich Provider/Model/Team dimensions), accumulates usage in DynamoDB, fires SNS budget alerts, and writes usage records to the audit Firehose. Event-driven — no HTTP, no Portkey contract, no authorization.

## What changed (lightest touch)

- Bespoke JSON logger → `gwcore.logging`.
- Operational EMF metrics for handler outcomes: a `RequestLatency` Timer, `EventsProcessed`, and `CostAttributionError` dimensioned by `Code` (`decode_error` | `extract_error` | `publish_error`).

## What was deliberately left as-is

The existing **billing** CloudWatch metrics (`TokensUsed`, `EstimatedCostUsd`, `CacheSavingsByTeam`, …) and the **usage** Firehose records are domain telemetry with their own Iceberg schema. Rewriting them onto gwcore's EMF/`AuditEvent` shapes would change the tables downstream billing reads from. gwcore observability **complements** them; it does not replace them.

## Tests

- New `TestObservability`: each operational metric (`EventsProcessed`, and the three `CostAttributionError` codes) fires on its path.
- **658 passing**, ruff clean, pyright 0/0/0, semgrep clean. Handler at 89% (remaining misses are pre-existing JWT/alert/Firehose helper branches, not in this diff).