### PR TITLE
refactor: migrate chargeback_report onto gwcore observability

### DIFF
--- a/src/chargeback_report/handler.py
+++ b/src/chargeback_report/handler.py
@@ -2,12 +2,15 @@
 
 Triggered by Step Functions on the 1st of each month. Queries DynamoDB
 usage and budget tables, generates an HTML report, and uploads to S3.
+
+Step-Functions-invoked, not HTTP / Portkey: no request authorization, and the
+report lands in S3 rather than the audit pipeline. Migrated onto gwcore
+(ADR-016) for the lightest touch — structured JSON logging plus operational EMF
+metrics for the report-generation outcome (success / failures by stage).
 """
 
 from __future__ import annotations
 
-import json
-import logging
 import os
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -19,24 +22,10 @@ from pydantic import ValidationError
 
 from chargeback_report.models import ReportData, ReportRequest, ReportResponse, TeamUsageSummary
 from chargeback_report.report_template import render_html
+from gwcore.logging import get_logger
+from gwcore.telemetry import Timer, emit_metric
 
-logger = logging.getLogger("chargeback_report")
-logger.setLevel(logging.INFO)
-if not logger.handlers:
-    _h = logging.StreamHandler()
-    _h.setFormatter(
-        logging.Formatter(
-            json.dumps(
-                {
-                    "timestamp": "%(asctime)s",
-                    "level": "%(levelname)s",
-                    "logger": "%(name)s",
-                    "message": "%(message)s",
-                }
-            )
-        )
-    )
-    logger.addHandler(_h)
+logger = get_logger("chargeback_report")
 
 USAGE_TABLE = os.environ.get("USAGE_TABLE", "gateway-usage")
 BUDGETS_TABLE = os.environ.get("BUDGETS_TABLE", "gateway-budgets")
@@ -226,18 +215,28 @@ def handler(event: dict[str, Any], _context: Any = None) -> dict[str, Any]:
     Input:  {"month": "2026-03", "output_format": "html"}
     Output: {"s3_url": "s3://...", "summary": "...", "team_count": N, "total_cost_usd": "X.XX", "month": "2026-03"}
     """
-    logger.info("Received chargeback report request: %s", json.dumps(event))
+    with Timer("RequestLatency", route="chargeback_report"):
+        return _handle(event)
 
+
+def _handle(event: dict[str, Any]) -> dict[str, Any]:
     try:
         request = ReportRequest.model_validate(event)
     except ValidationError as e:
+        # Surface only the error count, never the exception text — a pydantic
+        # repr can echo input values.
+        count = e.error_count()
         logger.exception("Invalid report request")
-        return {"statusCode": 400, "error": f"Invalid request: {e}"}
+        emit_metric("ChargebackError", 1, dimensions={"Code": "bad_request"})
+        return {"statusCode": 400, "error": f"Invalid request: {count} validation error(s)"}
+
+    logger.info("Generating chargeback report for month=%s", request.month)
 
     try:
         report_data = _build_report(request)
     except Exception:
         logger.exception("Failed to build report for %s", request.month)
+        emit_metric("ChargebackError", 1, dimensions={"Code": "build_error"})
         return {"statusCode": 500, "error": f"Failed to build report for {request.month}"}
 
     if not report_data.teams:
@@ -247,12 +246,14 @@ def handler(event: dict[str, Any], _context: Any = None) -> dict[str, Any]:
         report_html = render_html(report_data)
     except Exception:
         logger.exception("Failed to render HTML report")
+        emit_metric("ChargebackError", 1, dimensions={"Code": "render_error"})
         return {"statusCode": 500, "error": "Failed to render HTML report"}
 
     try:
         s3_url = _upload_report(report_html, request.month)
     except Exception:
         logger.exception("Failed to upload report to S3")
+        emit_metric("ChargebackError", 1, dimensions={"Code": "upload_error"})
         return {"statusCode": 500, "error": "Failed to upload report to S3"}
 
     summary = (
@@ -270,5 +271,6 @@ def handler(event: dict[str, Any], _context: Any = None) -> dict[str, Any]:
         month=request.month,
     )
 
+    emit_metric("ReportGenerated", 1, dimensions={"Route": "chargeback_report"})
     logger.info("Report generated: %s", summary)
     return response.model_dump(mode="json")

--- a/src/chargeback_report/handler.py
+++ b/src/chargeback_report/handler.py
@@ -223,10 +223,11 @@ def _handle(event: dict[str, Any]) -> dict[str, Any]:
     try:
         request = ReportRequest.model_validate(event)
     except ValidationError as e:
-        # Surface only the error count, never the exception text — a pydantic
-        # repr can echo input values.
+        # Surface only the error count, never the exception text — a pydantic v2
+        # repr can echo input values (input_value), so we must NOT log it via
+        # exc_info either. Log the count alone.
         count = e.error_count()
-        logger.exception("Invalid report request")
+        logger.warning("Invalid report request: %d validation error(s)", count)
         emit_metric("ChargebackError", 1, dimensions={"Code": "bad_request"})
         return {"statusCode": 400, "error": f"Invalid request: {count} validation error(s)"}
 

--- a/tests/test_chargeback_report.py
+++ b/tests/test_chargeback_report.py
@@ -463,3 +463,63 @@ class TestHandler:
         assert "total_cost_usd" in result
         # Decimal serialized as string in JSON mode
         assert float(result["total_cost_usd"]) == pytest.approx(125.50, rel=1e-2)
+
+
+# -- gwcore observability (ADR-016) -------------------------------------------
+
+
+class TestObservability:
+    """The migration adds operational EMF metrics for the report-generation
+    outcome. No audit events — the report lands in S3, not the audit pipeline."""
+
+    @patch("chargeback_report.handler.emit_metric")
+    @patch("chargeback_report.handler.s3")
+    @patch("chargeback_report.handler.dynamodb")
+    def test_success_emits_report_generated(self, mock_ddb: Any, mock_s3: Any, mock_metric: Any) -> None:
+        mock_table = MagicMock()
+        mock_table.scan.side_effect = [
+            {"Items": [TEAM_ALPHA_USAGE]},
+            {"Items": []},
+            {"Items": []},
+        ]
+        mock_ddb.Table.return_value = mock_table
+
+        result = handler({"month": "2026-03"})
+        assert "s3_url" in result
+        assert any(c.args and c.args[0] == "ReportGenerated" for c in mock_metric.call_args_list)
+
+    @patch("chargeback_report.handler.emit_metric")
+    def test_bad_request_emits_error_metric(self, mock_metric: Any) -> None:
+        result = handler({"month": "invalid"})
+        assert result["statusCode"] == 400
+        assert any(
+            c.args and c.args[0] == "ChargebackError" and c.kwargs.get("dimensions") == {"Code": "bad_request"}
+            for c in mock_metric.call_args_list
+        )
+
+    def test_bad_request_does_not_echo_payload(self) -> None:
+        # The ValidationError text must not leak input values into the response.
+        secret = "super-secret-value-2026"
+        result = handler({"month": secret})
+        assert result["statusCode"] == 400
+        assert secret not in result["error"]
+        assert "validation error" in result["error"].lower()
+
+    @patch("chargeback_report.handler.emit_metric")
+    @patch("chargeback_report.handler.render_html")
+    @patch("chargeback_report.handler.s3")
+    @patch("chargeback_report.handler.dynamodb")
+    def test_render_error_emits_metric(
+        self, mock_ddb: Any, mock_s3: Any, mock_render: Any, mock_metric: Any
+    ) -> None:
+        mock_table = MagicMock()
+        mock_table.scan.return_value = {"Items": []}
+        mock_ddb.Table.return_value = mock_table
+        mock_render.side_effect = RuntimeError("template boom")
+
+        result = handler({"month": "2026-03"})
+        assert result["statusCode"] == 500
+        assert any(
+            c.args and c.args[0] == "ChargebackError" and c.kwargs.get("dimensions") == {"Code": "render_error"}
+            for c in mock_metric.call_args_list
+        )

--- a/tests/test_chargeback_report.py
+++ b/tests/test_chargeback_report.py
@@ -521,3 +521,33 @@ class TestObservability:
             c.args and c.args[0] == "ChargebackError" and c.kwargs.get("dimensions") == {"Code": "render_error"}
             for c in mock_metric.call_args_list
         )
+
+    @patch("chargeback_report.handler.emit_metric")
+    @patch("chargeback_report.handler.dynamodb")
+    def test_build_error_emits_metric(self, mock_ddb: Any, mock_metric: Any) -> None:
+        mock_table = MagicMock()
+        mock_table.scan.side_effect = Exception("DynamoDB timeout")
+        mock_ddb.Table.return_value = mock_table
+
+        result = handler({"month": "2026-03"})
+        assert result["statusCode"] == 500
+        assert any(
+            c.args and c.args[0] == "ChargebackError" and c.kwargs.get("dimensions") == {"Code": "build_error"}
+            for c in mock_metric.call_args_list
+        )
+
+    @patch("chargeback_report.handler.emit_metric")
+    @patch("chargeback_report.handler.s3")
+    @patch("chargeback_report.handler.dynamodb")
+    def test_upload_error_emits_metric(self, mock_ddb: Any, mock_s3: Any, mock_metric: Any) -> None:
+        mock_table = MagicMock()
+        mock_table.scan.return_value = {"Items": [TEAM_ALPHA_USAGE]}
+        mock_ddb.Table.return_value = mock_table
+        mock_s3.put_object.side_effect = Exception("S3 access denied")
+
+        result = handler({"month": "2026-03"})
+        assert result["statusCode"] == 500
+        assert any(
+            c.args and c.args[0] == "ChargebackError" and c.kwargs.get("dimensions") == {"Code": "upload_error"}
+            for c in mock_metric.call_args_list
+        )

--- a/tests/test_chargeback_report.py
+++ b/tests/test_chargeback_report.py
@@ -509,9 +509,7 @@ class TestObservability:
     @patch("chargeback_report.handler.render_html")
     @patch("chargeback_report.handler.s3")
     @patch("chargeback_report.handler.dynamodb")
-    def test_render_error_emits_metric(
-        self, mock_ddb: Any, mock_s3: Any, mock_render: Any, mock_metric: Any
-    ) -> None:
+    def test_render_error_emits_metric(self, mock_ddb: Any, mock_s3: Any, mock_render: Any, mock_metric: Any) -> None:
         mock_table = MagicMock()
         mock_table.scan.return_value = {"Items": []}
         mock_ddb.Table.return_value = mock_table


### PR DESCRIPTION
## What

Migrates **chargeback_report** onto `gwcore` (ADR-016). The last of the service migrations.

`chargeback_report` is **Step-Functions-invoked** (monthly): it scans the DynamoDB usage + budget tables, renders an HTML report, and uploads it to S3. No HTTP, no Portkey contract, no authorization; the report lands in S3, not the audit pipeline.

## What changed (lightest touch)

- Bespoke JSON logger → `gwcore.logging`.
- `RequestLatency` Timer; `ReportGenerated` metric on success; `ChargebackError` dimensioned by `Code` (`bad_request` | `build_error` | `render_error` | `upload_error`).
- **Stopped echoing the `ValidationError` text into the 400 response** — a pydantic repr can include input values; surface only the error count. (Same PII-safety class Copilot flagged on #224.) Also replaced the `json.dumps(event)` request log with a structured `month=` field.

## Tests

- New `TestObservability`: each metric fires on its path; the bad-request response never echoes the payload; the render-error path is covered.
- **662 passing**, ruff clean, pyright 0/0/0, semgrep clean. Handler at 88% (remaining misses are pre-existing DDB-query helper branches, not in this diff).