### PR TITLE
docs: sync README + Starlight site to main; fix URL integrity (incl. home /ai-gateway.md 404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The infrastructure follows a single-region, two-AZ deployment on AWS:
 - **CloudWatch** -- Log groups for gateway and OTel collector, saved Logs Insights queries, and an operational dashboard (requests, errors, latency, top endpoints by provider).
 - **Secrets Manager** -- Stores provider API keys (OpenAI, Anthropic, Google, Azure) injected into ECS tasks at runtime.
 
+The deployment is split into two planes ([ADR-014](adr/014-two-plane-architecture-split.md)): the **data plane** above carries inference traffic on the ALB, while a **control plane** of Lambda services behind an API Gateway REST API (with a Cognito authorizer) handles teams, budgets, routing, pricing, usage, and content-scanner configuration. All control-plane services share one Python package, `src/gwcore/`, that provides a single authentication path, a consistent response/error/pagination contract, in-process + ETag caching, an append-only audit trail (Kinesis Firehose → Apache Iceberg on S3 Tables), and uniform EMF metrics + structured logging. See [ADR-016](adr/016-control-plane-api-foundation.md).
+
 A detailed Mermaid architecture diagram is available in the `docs/` directory.
 
 ## Prerequisites
@@ -211,6 +213,7 @@ Architectural Decision Records are in the `adr/` directory.
 | [013](adr/013-identity-center-saml-federation.md) | Identity Center SAML/OIDC Federation for User SSO | Accepted |
 | [014](adr/014-two-plane-architecture-split.md) | Two-Plane Architecture Split (ALB Inference + API Gateway Admin) | Accepted |
 | [015](adr/015-openai-responses-bedrock-mantle-proxy.md) | OpenAI Responses → Bedrock mantle proxy (openai provider + custom_host, no fork) | Accepted |
+| [016](adr/016-control-plane-api-foundation.md) | Control-Plane API Foundation (`gwcore` shared package) | Accepted |
 
 ## Scripts
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,10 +1,49 @@
 import { defineConfig } from "astro/config";
+import path from "node:path";
+import { readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import starlight from "@astrojs/starlight";
 import sitemap from "@astrojs/sitemap";
 import mermaid from "astro-mermaid";
 import starlightPageActions from "starlight-page-actions";
 import starlightLlmsTxt from "starlight-llms-txt";
 import remarkGfm from "remark-gfm";
+
+const SITE_BASE = "/ai-gateway";
+const DOCS_ROOT = "src/content/docs";
+
+/**
+ * Integration: fix the home page's "copy as markdown" action URL.
+ *
+ * starlight-page-actions builds the markdown href as
+ * `Astro.url.pathname.replace(/\/$/, "") + ".md"`. For every page that yields a
+ * real file (`/ai-gateway/user-guide/` -> `/ai-gateway/user-guide.md`), but for
+ * the site root it collapses `/ai-gateway/` -> `/ai-gateway` -> `/ai-gateway.md`,
+ * which sits OUTSIDE the base path and cannot be served by a project Pages site.
+ * The actual home markdown lives at `/ai-gateway/index.md`. Rewrite just that one
+ * href in the built home page. Self-contained, no node_modules patch.
+ */
+function fixHomeMarkdownActionUrl() {
+  return {
+    name: "fix-home-markdown-action-url",
+    hooks: {
+      "astro:build:done": async ({ dir, logger }) => {
+        const home = fileURLToPath(new URL("./index.html", dir));
+        const bad = `href="${SITE_BASE}.md"`;
+        const good = `href="${SITE_BASE}/index.md"`;
+        try {
+          const html = await readFile(home, "utf-8");
+          if (html.includes(bad)) {
+            await writeFile(home, html.split(bad).join(good));
+            logger.info(`Rewrote home markdown action: ${bad} -> ${good}`);
+          }
+        } catch (err) {
+          logger.warn(`Could not post-process home page: ${err}`);
+        }
+      },
+    },
+  };
+}
 
 export default defineConfig({
   site: "https://theagenticguy.github.io",
@@ -89,6 +128,7 @@ export default defineConfig({
       ],
     }),
     sitemap(),
+    fixHomeMarkdownActionUrl(),
   ],
 
   markdown: {
@@ -102,30 +142,60 @@ export default defineConfig({
 });
 
 /**
- * Remark plugin: rewrites relative .md/.mdx links to trailing-slash URLs.
- * Keeps raw markdown links working on GitHub while producing correct URLs
- * for the built Starlight site.
+ * Remark plugin: rewrites relative .md/.mdx links to site-absolute,
+ * trailing-slash Starlight URLs.
+ *
+ * Why site-absolute and not just `.md` -> `/`: Starlight serves every page as
+ * a trailing-slash directory (`/admin-guide/deployment/`). A *relative* target
+ * like `environments/` then resolves against the current directory in the
+ * browser -> `/admin-guide/deployment/environments/` (a 404). Relative links
+ * only happened to work from index pages. Resolving each link against the
+ * page's own route and emitting an absolute `/ai-gateway/...` URL fixes leaf
+ * pages and is position-independent. Raw `.md` links still work on GitHub
+ * because this rewrite only runs at build time.
  */
 function remarkStripMdLinks() {
-  return (tree) => {
-    visitLinks(tree);
+  return (tree, file) => {
+    // Directory of the source file relative to src/content/docs. Relative
+    // markdown links resolve against the *source file's directory*, not the
+    // rendered route — e.g. a link from "getting-started/prerequisites.mdx" to
+    // "authentication.md" targets the sibling "getting-started/authentication",
+    // not "getting-started/prerequisites/authentication".
+    const abs = (file?.path ?? "").replace(/\\/g, "/");
+    const idx = abs.indexOf(`${DOCS_ROOT}/`);
+    let pageDir = "";
+    if (idx !== -1) {
+      const relFromDocs = abs.slice(idx + DOCS_ROOT.length + 1);
+      const dir = path.posix.dirname(relFromDocs);
+      pageDir = dir === "." ? "" : dir;
+    }
+    visitLinks(tree, pageDir);
   };
 }
 
-function visitLinks(node) {
+function visitLinks(node, pageDir) {
   if (node.type === "link" && node.url) {
-    // Only process relative links (not http://, mailto:, etc.)
-    if (!/^[a-z]+:/i.test(node.url)) {
-      const [path, fragment] = node.url.split("#");
-      if (path.endsWith(".md") || path.endsWith(".mdx")) {
-        const stripped = path.replace(/\.mdx?$/, "/");
-        node.url = fragment ? `${stripped}#${fragment}` : stripped;
+    // Only process relative links (not http://, mailto:, anchors, etc.)
+    if (!/^[a-z]+:/i.test(node.url) && !node.url.startsWith("/") && !node.url.startsWith("#")) {
+      const [rawPath, fragment] = node.url.split("#");
+      if (rawPath.endsWith(".md") || rawPath.endsWith(".mdx")) {
+        const stripped = rawPath.replace(/\.mdx?$/, "");
+        // Resolve the link target against the page's own source directory, then
+        // make it site-absolute with the configured base and a trailing slash.
+        let resolved = path.posix.normalize(
+          path.posix.join("/", pageDir, stripped),
+        );
+        // An index page renders at its directory route, so a link to index.md
+        // maps to the containing dir (e.g. "index" -> "/", "x/index" -> "/x").
+        resolved = resolved.replace(/(^|\/)index$/, "$1");
+        const url = `${SITE_BASE}${resolved}/`.replace(/\/{2,}/g, "/");
+        node.url = fragment ? `${url}#${fragment}` : url;
       }
     }
   }
   if (node.children) {
     for (const child of node.children) {
-      visitLinks(child);
+      visitLinks(child, pageDir);
     }
   }
 }

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -13,15 +13,21 @@ const SITE_BASE = "/ai-gateway";
 const DOCS_ROOT = "src/content/docs";
 
 /**
- * Integration: fix the home page's "copy as markdown" action URL.
+ * Integration: fix the home page's "copy / view as markdown" action targets.
  *
- * starlight-page-actions builds the markdown href as
- * `Astro.url.pathname.replace(/\/$/, "") + ".md"`. For every page that yields a
- * real file (`/ai-gateway/user-guide/` -> `/ai-gateway/user-guide.md`), but for
- * the site root it collapses `/ai-gateway/` -> `/ai-gateway` -> `/ai-gateway.md`,
- * which sits OUTSIDE the base path and cannot be served by a project Pages site.
- * The actual home markdown lives at `/ai-gateway/index.md`. Rewrite just that one
- * href in the built home page. Self-contained, no node_modules patch.
+ * starlight-page-actions derives the markdown path as
+ * `Astro.url.pathname.replace(/\/$/, "")` and appends `.md`. For every normal
+ * page that yields a real file (`/ai-gateway/user-guide/` -> `/ai-gateway/user-guide.md`),
+ * but for the SITE ROOT it collapses `/ai-gateway/` -> `/ai-gateway` -> `/ai-gateway.md`,
+ * which sits OUTSIDE the base path and cannot be served by a project Pages site
+ * (404). The actual home markdown lives at `/ai-gateway/index.md`.
+ *
+ * Two consumers on the home page need fixing, both rooted at that same path:
+ *   1. the "View in Markdown" dropdown link  -> `<a href="/ai-gateway.md">`
+ *   2. the "Copy Markdown" button            -> `<button data-path="/ai-gateway">`,
+ *      whose client JS does `fetch(`${dataset.path}.md`)`.
+ * Rewrite both in the built home page so each resolves to `/ai-gateway/index.md`.
+ * Self-contained; no node_modules patch.
  */
 function fixHomeMarkdownActionUrl() {
   return {
@@ -29,14 +35,23 @@ function fixHomeMarkdownActionUrl() {
     hooks: {
       "astro:build:done": async ({ dir, logger }) => {
         const home = fileURLToPath(new URL("./index.html", dir));
-        const bad = `href="${SITE_BASE}.md"`;
-        const good = `href="${SITE_BASE}/index.md"`;
+        const replacements = [
+          // dropdown link href
+          [`href="${SITE_BASE}.md"`, `href="${SITE_BASE}/index.md"`],
+          // copy-button data-path (JS appends ".md" -> /ai-gateway/index.md)
+          [`data-path="${SITE_BASE}"`, `data-path="${SITE_BASE}/index"`],
+        ];
         try {
-          const html = await readFile(home, "utf-8");
-          if (html.includes(bad)) {
-            await writeFile(home, html.split(bad).join(good));
-            logger.info(`Rewrote home markdown action: ${bad} -> ${good}`);
+          let html = await readFile(home, "utf-8");
+          let changed = false;
+          for (const [bad, good] of replacements) {
+            if (html.includes(bad)) {
+              html = html.split(bad).join(good);
+              changed = true;
+              logger.info(`Rewrote home markdown action: ${bad} -> ${good}`);
+            }
           }
+          if (changed) await writeFile(home, html);
         } catch (err) {
           logger.warn(`Could not post-process home page: ${err}`);
         }

--- a/docs/src/content/docs/adrs/015-openai-responses-bedrock-mantle-proxy.md
+++ b/docs/src/content/docs/adrs/015-openai-responses-bedrock-mantle-proxy.md
@@ -1,0 +1,62 @@
+---
+title: "ADR-015: OpenAI Responses → Bedrock mantle proxy"
+description: Codex + GPT-5.5/5.4 (Responses-only) route through the gateway via the openai provider with a custom_host pointed at the Bedrock mantle endpoint — a proxy, not a fork or a bypass.
+sidebar:
+  order: 15
+---
+
+**Status**: Accepted
+**Date**: 2026-06-11
+**Deciders**: AI Engineering NAMER
+
+## Context
+
+The OpenAI Codex client is **Responses-API-only** (`wire_api = "chat"` was removed upstream and is rejected at config parse). The flagship GPT-5.5 / GPT-5.4 models on Amazon Bedrock are **also Responses-only**, served at the OpenAI-compatible mantle endpoint:
+
+```
+https://bedrock-mantle.<region>.api.aws/openai/v1/responses
+```
+
+Portkey OSS's `bedrock` provider maps OpenAI Chat Completions -> Bedrock **Converse** and has **no** `createModelResponse` (Responses) implementation. An early design read this as "the gateway cannot serve Codex/GPT-5.5 to Bedrock," and proposed either (a) forking Portkey to build a Responses->Converse translator or (b) routing Codex *around* the gateway directly to mantle. Both were wrong.
+
+## Decision
+
+Serve the OpenAI Responses lane **through the gateway, with stock Portkey and no fork**, by treating mantle as what it is -- a native OpenAI-compatible upstream. Use Portkey's `openai` provider (which **does** implement `createModelResponse`) with a `custom_host` pointed at the mantle base:
+
+```json
+{ "provider": "openai",
+  "custom_host": "https://bedrock-mantle.<region>.api.aws/openai/v1",
+  "api_key": "<BEDROCK_API_KEY>" }
+```
+
+The gateway rewrites only the upstream host, preserves the `/responses` path verbatim, and re-issues `Authorization: Bearer <Bedrock API key>` (which mantle's OpenAI-compatible path accepts). `before_request_hooks`, logging, and cost attribution all run -- so the flagship lane stays governed and inside the customer AWS boundary.
+
+**Path is per model family** (verified live): GPT-5.5/5.4 use the mantle `/openai/v1` base; gpt-oss-120b/-20b use the `/v1` base (Chat Completions, served by the existing `bedrock` provider -> Converse). The gateway sets `custom_host` per family.
+
+## Verification
+
+Confirmed live (Portkey OSS main @ `669825c`, local spike, 2026-06-11):
+
+- A Codex-shaped Responses request through the gateway returns a valid completion from mantle for both `openai.gpt-oss-20b` (`/v1`) and `openai.gpt-5.5` (`/openai/v1`).
+- SSE streaming relays faithfully; the terminal `response.completed` event carries `usage`.
+- The `custom_host` is honored and the `/responses` path preserved (`src/handlers/services/providerContext.ts` `getFullURL`; `src/providers/openai/api.ts` `getEndpoint`).
+
+## Consequences
+
+**Positive**: No fork, no Converse-translation maintenance burden; the flagship lane keeps gateway hooks, logging, and isolation. Retires the bypass and fork options.
+
+**Negative / caveats**:
+
+- The gateway holds a Bedrock API key as a static bearer (Portkey OSS has no refreshing-bearer loop for the `openai` provider) -- use a long-lived key or an external rotator.
+- OSS does not parse `usage` on **streamed** responses; per-stream cost attribution needs a small `afterRequestHook` / stream tee (additive, not a fork).
+- Because the lane uses the `openai` provider, the `custom_host` **must be pinned** and caller-supplied `custom_host` overrides rejected, or the gateway can route prompts to `api.openai.com` (the egress hole was demonstrated live). Egress to OpenAI SaaS is denied at the VPC as defense-in-depth.
+
+## Supersedes / amends
+
+Amends **ADR-006**: `/v1/responses` is served by the gateway for the `openai` provider, and the OpenAI-on-Bedrock lane uses that provider with a mantle `custom_host` -- Responses traffic flows **through** the gateway, not around it. The earlier "bypass the gateway" and "fork a `bedrock-responses` provider" framings are retracted.
+
+## Sources
+
+- AWS -- Get started with OpenAI GPT-5.5/GPT-5.4 and Codex on Amazon Bedrock; Bedrock mantle inference docs.
+- Portkey OSS `src/handlers/services/providerContext.ts`, `src/providers/openai/api.ts`, `src/handlers/modelResponsesHandler.ts` (verified at commit `669825c`).
+- Local spike `~/workplace/portkey-mantle-spike` (2026-06-11).

--- a/docs/src/content/docs/adrs/016-control-plane-api-foundation.md
+++ b/docs/src/content/docs/adrs/016-control-plane-api-foundation.md
@@ -1,0 +1,87 @@
+---
+title: "ADR-016: Control-Plane API Foundation (gwcore)"
+description: A shared gwcore package gives all control-plane Lambdas one auth path, a consistent response/pagination contract, an audit trail, and uniform observability.
+sidebar:
+  order: 16
+---
+
+**Status**: Accepted
+**Date**: 2026-06-24
+**Deciders**: AI Engineering NAMER
+**Builds on**: ADR-005 (ALB JWT), ADR-008 (per-team clients), ADR-013 (SSO federation), ADR-014 (two-plane split)
+
+## Context
+
+The admin/control plane is eleven Lambda services (ADR-014). They share no code: each re-implements JWT handling, response building, error mapping, and logging. Two concrete problems result.
+
+1. **Divergent, duplicated auth.** `budget_admin/auth.py` checks the `scope` claim for `"admin"`; `team_registration/auth.py` checks for `"https://gateway.internal/admin"`. Same intent, two different strings -- a latent authorization inconsistency. Both decode the JWT with base64 only (no signature verification), which is correct *only* because API Gateway's Cognito authorizer already verified it upstream.
+2. **No shared envelope, pagination, audit, or telemetry.** Every handler hand-rolls `_build_response`, returns ad-hoc error shapes, and emits unstructured logs. There is no audit trail for control-plane mutations and no consistent metrics.
+
+As the portal (ADR-pending) turns these APIs into a human-facing surface, the plane needs a foundation: one authentication/authorization path, a consistent response + pagination contract, caching, an audit trail, and uniform observability.
+
+## Decision
+
+Introduce a shared package **`src/gwcore/`** (not `platform/` -- that name shadows the stdlib `platform` module under `pythonpath=["src"]` and breaks boto3). Every control-plane handler imports `gwcore` instead of re-implementing primitives. `gwcore` ships seven modules:
+
+| Module | Responsibility |
+|---|---|
+| `gwcore.auth` | Principal extraction; **two verification modes** (see below); unified scope+claim RBAC |
+| `gwcore.responses` | Response envelope, typed errors -> HTTP, cursor pagination |
+| `gwcore.cache` | In-process TTL cache (warm-Lambda reuse) + read-through helper + ETag |
+| `gwcore.audit` | Append-only audit events -> Firehose (-> Iceberg, ADR-pending) |
+| `gwcore.logging` | Structured JSON logs with correlation id (request id) |
+| `gwcore.telemetry` | CloudWatch EMF metrics + OTEL GenAI-convention span attributes |
+| `gwcore.errors` | Typed exception hierarchy mapped to HTTP status by `responses` |
+
+### AuthN — two modes, one principal
+
+The decisive design point: the control plane has **two ingress paths with different trust properties**, so `gwcore.auth` supports two verification modes that both yield the same `Principal` object.
+
+- **`trusted_edge` mode** (default for the existing admin handlers): API Gateway's Cognito authorizer has already verified the JWT signature, audience, and expiry before invoking Lambda. The handler only needs to *read* claims. `gwcore` decodes the payload (base64, no re-verify) -- preserving today's behavior but through one code path, not eleven.
+- **`verify` mode** (for the token-exchange endpoint and any handler reachable without the authorizer): full RS256 signature verification against the Cognito JWKS, with `iss`/`exp`/`aud` checks. JWKS is fetched once and cached in-process (warm-Lambda reuse) with a TTL and a forced refresh on unknown-`kid`, so steady-state verification is zero-network.
+
+A `Principal` carries `sub`, `team`, `cost_center`, `tenant_tier`, `scopes`, `client_id`, and `token_use`. The IdP-group->claim mapping that populates `team`/`cost_center`/`tier` already exists in the `pre_token` Lambda (ADR-013).
+
+### AuthZ — unified, declarative
+
+One `require(principal, scopes=..., tiers=...)` gate replaces the divergent string checks. Scopes are matched against a canonical set; the historical `"admin"` and `"https://gateway.internal/admin"` are both accepted during migration via an alias table, so neither existing handler breaks. Authorization decisions emit an audit event regardless of outcome (allow *and* deny), so denials are observable.
+
+### Caching & performance
+
+- **JWKS cache** (above) removes per-request network I/O from `verify` mode.
+- **Read-through TTL cache** for hot, slowly-changing config (pricing table, routing configs, tier defaults): `gwcore.cache.read_through(key, loader, ttl)`. In-process only -- survives across invocations on a warm Lambda, evaporates on cold start, no external dependency. This is deliberately *not* the response cache; LLM response caching stays at Redis (ADR-012).
+- **HTTP caching**: GET responses carry an `ETag` (content hash) and honor `If-None-Match` -> `304`, so the portal and CLIs avoid re-transferring unchanged config.
+- **API Gateway stage cache** is enabled for idempotent GET routes (pricing, catalog) with a short TTL, taking read load off Lambda entirely for the hottest reads.
+- **Pagination**: list endpoints return an opaque cursor (base64 of the DynamoDB `LastEvaluatedKey`), never offset -- O(1) regardless of table size.
+- Cold-start: `gwcore` has one third-party import (`pyjwt`); boto3 clients are created lazily and module-scoped for warm reuse.
+
+### Audit, logging, monitoring
+
+- **Audit** (`gwcore.audit`): every mutating control-plane call and every authz decision emits a structured `AuditEvent` (actor, action, resource, before/after where applicable, status, source IP, request id) to a Kinesis Firehose stream. Firehose lands it in Apache Iceberg on S3 Tables (ADR-pending) for ACID, compaction, and Athena queryability. Emission is best-effort and never fails the request.
+- **Logging** (`gwcore.logging`): JSON logs with a per-request correlation id taken from the API Gateway request id, so a single request is greppable across handler + audit + metrics.
+- **Monitoring** (`gwcore.telemetry`): CloudWatch EMF metric blocks (no `PutMetricData` call on the hot path) for request count, latency, authz-deny count, and per-route error rate; plus OTEL GenAI semantic-convention attributes so control-plane spans join the same trace namespace as the inference plane.
+
+## Alternatives considered
+
+| Option | Verdict |
+|---|---|
+| **Keep per-service auth, just fix the string mismatch** | Rejected. Fixes one bug, leaves the duplication and the missing audit/telemetry. The portal needs a consistent contract across all routes. |
+| **A Lambda layer instead of a `src/` package** | Rejected for now. A layer decouples deploy cadence but complicates local `pytest` (`pythonpath=["src"]` already makes a `src/` package importable in tests with zero packaging). Revisit if cold-start size becomes an issue. |
+| **Powertools for AWS Lambda (Python)** | Strong option -- it ships EMF metrics, structured logging, and a JWT/authz helper. Rejected as a hard dependency to keep the supply-chain surface minimal (ADR-001/004 ethos) and avoid a large import on cold start, but `gwcore`'s telemetry/logging deliberately mirror Powertools' EMF + structured-log shapes so a later swap is mechanical. |
+| **API Gateway Lambda authorizer (custom) instead of Cognito authorizer** | Rejected. The Cognito `COGNITO_USER_POOLS` authorizer already validates signature + scopes natively (ADR-014); a custom authorizer would re-implement that and add latency. `gwcore`'s `verify` mode covers only the non-authorizer paths. |
+| **DAX / ElastiCache for the read-through cache** | Rejected. The hot config is tiny and slowly-changing; an in-process TTL cache on warm Lambdas plus the API Gateway stage cache covers it without new infrastructure or per-request network cost. |
+
+## Consequences
+
+**Positive**: one authentication/authorization path (closes the scope-mismatch bug); a consistent response + error + pagination contract the portal can target; an audit trail and uniform metrics the plane never had; near-zero added latency (in-process caches, EMF, lazy clients). Existing handlers migrate incrementally -- `gwcore` accepts both legacy scope strings during the transition.
+
+**Negative**: one new shared package to own and version; handlers must be refactored to adopt it (incremental, not big-bang); `pyjwt[crypto]` is a new runtime dependency (small, widely used, pulls in `cryptography`).
+
+**Neutral**: `gwcore` is import-only with no I/O at import time, so it does not change cold-start behavior beyond the `pyjwt` import.
+
+## Sources
+
+- ADR-013 -- Identity Center SAML/OIDC federation + `pre_token` claim mapping
+- ADR-014 -- Two-plane split (API Gateway + Cognito authorizer for the admin plane)
+- AWS -- InvokeGuardrailChecks, CloudWatch EMF, API Gateway stage caching, S3 Tables (Iceberg)
+- The existing divergent `budget_admin/auth.py` and `team_registration/auth.py`

--- a/docs/src/content/docs/developer-guide/adr-index.md
+++ b/docs/src/content/docs/developer-guide/adr-index.md
@@ -29,6 +29,7 @@ ADRs are stored in the `adr/` directory at the repository root.
 | [013](/ai-gateway/adrs/013-identity-center-saml-federation/) | Identity Center SAML/OIDC Federation | Proposed | SAML 2.0 and OIDC federation with the Cognito User Pool, plus a Pre-Token-Generation V2 Lambda for IdP group-to-claim mapping. |
 | [014](/ai-gateway/adrs/014-two-plane-architecture-split/) | Two-Plane Architecture Split | Accepted | ALB stays on the inference path; admin APIs (teams, budgets, routing, scanner, pricing, usage) move behind API Gateway with a Cognito authorizer. Eliminates duplicated JWT validation across handlers. |
 | [015](/ai-gateway/adrs/015-openai-responses-bedrock-mantle-proxy/) | OpenAI Responses → Bedrock mantle proxy | Accepted | Codex + GPT-5.5/5.4 (Responses-only) route through the gateway via the `openai` provider with a `custom_host` pointed at the Bedrock mantle endpoint — a proxy, not a fork or a bypass. Amends ADR-006; retracts the earlier "bypass the gateway / fork a `bedrock-responses` provider" framing. |
+| [016](/ai-gateway/adrs/016-control-plane-api-foundation/) | Control-Plane API Foundation (`gwcore`) | Accepted | A shared `src/gwcore/` package gives all control-plane Lambdas one auth path (two verification modes, one `Principal`), a consistent response/error/cursor-pagination contract, in-process + ETag caching, an append-only audit trail (Firehose → Iceberg), and uniform EMF + structured-log observability. Closes the divergent-scope auth bug surfaced under ADR-014; handlers migrate incrementally. |
 
 ## Creating a New ADR
 

--- a/docs/src/content/docs/developer-guide/architecture.md
+++ b/docs/src/content/docs/developer-guide/architecture.md
@@ -139,6 +139,8 @@ The data plane handles high-volume, latency-sensitive LLM API requests. Every re
 
 The control plane handles low-volume, correctness-sensitive configuration and management operations. All admin endpoints sit behind a single API Gateway REST API with a shared Cognito authorizer, gated by the `enable_admin_api` feature flag.
 
+**Shared foundation (`gwcore`).** Every control-plane Lambda imports the shared `src/gwcore/` package instead of re-implementing primitives. `gwcore` provides one authentication path (two verification modes -- `trusted_edge` reads claims behind the Cognito authorizer, `verify` does full RS256 against cached JWKS -- both yielding one `Principal`), a unified `require(...)` authorization gate, a consistent response/error envelope with opaque-cursor pagination, in-process TTL + ETag caching, an append-only audit trail, and uniform EMF metrics + structured logging. All twelve services run on it. See [ADR-016](/ai-gateway/adrs/016-control-plane-api-foundation/).
+
 **Admin API routes:**
 
 | Route | Module | Lambda Source | Purpose |
@@ -156,13 +158,13 @@ The control plane handles low-volume, correctness-sensitive configuration and ma
 |---|---|---|
 | State storage | DynamoDB | Budget definitions, usage counters (atomic), team configs, routing rules |
 | Chargeback reports | Step Functions + Lambda | Monthly cost reports per team (`modules/chargeback`) |
-| Audit trail | Kinesis Firehose → S3 (Parquet) | Hive-partitioned compliance audit log (`modules/audit_log`) |
+| Audit trail | Kinesis Firehose → Apache Iceberg on S3 Tables | `gwcore.audit` records every mutation and authz decision; Firehose lands them in an Iceberg table for ACID + Athena queries (`modules/audit_pipeline`, ADR-016). The earlier Parquet + Glue path (`modules/audit_log`) remains for compatibility. |
 | Cost attribution | CloudWatch subscription + Lambda | Parses gateway logs, emits per-team/model cost metrics (`modules/cost_attribution`) |
 | Feature flags | AppConfig | Hot-path toggles (content scanner on/off) without redeployment (`modules/appconfig`) |
 | Budget alerts | SNS | Notifications when teams hit warning (80%) or hard (100%) budget thresholds |
 | CVE monitoring | Amazon Inspector | Continuous vulnerability scanning of ECR images (`modules/inspector`) |
 
-**Terraform modules** backing the control plane: `admin_api`, `team_registration`, `routing`, `budgets`, `chargeback`, `audit_log`, `cost_attribution`, `inspector`.
+**Terraform modules** backing the control plane: `admin_api`, `api_foundation`, `team_registration`, `routing`, `budgets`, `chargeback`, `audit_log`, `audit_pipeline`, `cost_attribution`, `inspector`.
 
 ### Why Two Planes
 
@@ -234,7 +236,7 @@ flowchart TD
 
 ### Module Responsibilities
 
-The infrastructure is organized into 17 modules. The table below groups them by plane.
+The infrastructure is organized into 19 modules. The table below groups them by plane.
 
 **Foundation modules** (shared by both planes):
 
@@ -260,12 +262,14 @@ The infrastructure is organized into 17 modules. The table below groups them by 
 | Module | Resources | Key Outputs |
 |--------|-----------|---------|
 | **admin_api** | API Gateway REST API, Cognito authorizer, per-path Lambda integrations, CloudWatch access logging | `api_url`, `api_execution_arn` |
+| **api_foundation** | Deployed control-plane stage (method-level GET cache + throttling), per-tenant usage plans + API keys, regional WAF, JSON access logging, the token-exchange route, and alarms + dashboard for the `gwcore` EMF metrics (ADR-016) | `stage_invoke_url`, `dashboard_name` |
 | **team_registration** | Lambda + DynamoDB for self-service team onboarding | `function_url` |
 | **routing** | Lambda + DynamoDB for dynamic routing config management | `function_url` |
 | **budgets** | DynamoDB tables (budget definitions + usage counters), SNS budget alerts topic | `budgets_table_name`, `usage_table_name`, `budget_alerts_topic_arn` |
 | **cost_attribution** | CloudWatch subscription filter, Lambda (log parser → custom metrics), budget alert integration | -- |
 | **chargeback** | Step Functions state machine, Lambda for monthly cost report generation | -- |
 | **audit_log** | Kinesis Firehose (Parquet), S3 bucket (Hive-partitioned), Glue catalog | `s3_bucket_name`, `firehose_stream_name` |
+| **audit_pipeline** | Kinesis Firehose → Apache Iceberg on S3 Tables — the `gwcore.audit` sink (ACID commits, Athena/Spark, no Glue crawler). Successor to `audit_log` (ADR-016) | `firehose_stream_name`, `firehose_stream_arn`, `table_bucket_arn` |
 | **inspector** | Amazon Inspector enhanced scanning for ECR repositories | -- |
 
 ### Why This Order

--- a/docs/src/content/docs/developer-guide/code-quality.md
+++ b/docs/src/content/docs/developer-guide/code-quality.md
@@ -254,7 +254,7 @@ The project uses 12 security tools across development, CI, and deployment phases
 | [TFLint](https://github.com/terraform-linters/tflint) | IaC | Terraform linting with AWS ruleset | CI |
 
 :::caution[Trivy supply chain advisory]
-CVE-2026-28353 affected the trivy Go module (Feb-Mar 2026). The CLI binary was unaffected. Mitigation: pin trivy versions in `mise.toml` and verify checksums. See [ADR-004](adr-index.md) for details.
+CVE-2026-28353 affected the trivy Go module (Feb-Mar 2026). The CLI binary was unaffected. Mitigation: pin trivy versions in `mise.toml` and verify checksums. See [ADR-004](../adrs/004-security-pipeline-composition.md) for details.
 :::
 
 


### PR DESCRIPTION
## What

Syncs the README and the Astro/Starlight docs site to the current `main` (gwcore / ADR-016 landed in code but were missing from the docs), and fixes URL integrity across the whole built site — including the live **`/ai-gateway.md` 404** on the home page's markdown actions.

## The 404

The home page's "Copy Markdown" button and "View in Markdown" dropdown both point at `https://theagenticguy.github.io/ai-gateway.md`, which 404s. Root cause: `starlight-page-actions` derives the markdown path as `pathname.replace(/\/$/, "") + ".md"`. For normal pages that yields a real file (`/ai-gateway/user-guide/` → `/ai-gateway/user-guide.md`); for the **site root** it collapses `/ai-gateway/` → `/ai-gateway` → `/ai-gateway.md`, which sits outside the base path and can't be served by a project Pages site. The real file is `/ai-gateway/index.md` (verified `200` live).

Fix: an `astro:build:done` integration rewrites both home-page consumers to `/ai-gateway/index.md` — the dropdown `<a href>` and the button's `data-path` (whose JS fetches `${data-path}.md`). No `node_modules` patch.

## Content sync

- New docs ADR pages **015** (OpenAI Responses → Bedrock mantle proxy) and **016** (Control-Plane API Foundation / gwcore). The dev-guide ADR index already linked to 015 but the page didn't exist — that was a second broken link, now resolved.
- `adr-index.md`: added the 016 row.
- `architecture.md`: gwcore foundation subsection on the control plane, `api_foundation` + `audit_pipeline` module rows, module count 17 → 19, audit-trail row updated to Firehose → Iceberg.
- `README.md`: ADR-016 row + control-plane/gwcore paragraph.
- `code-quality.md`: fixed an `[ADR-004]` link that pointed at `adr-index.md`.

## Link-integrity fix (all leaf pages)

`remarkStripMdLinks` emitted *relative* targets (`environments/`) that only resolved from index pages; from leaf pages (served as trailing-slash dirs) they 404'd. Rewrote it to emit **site-absolute** URLs resolved against each page's source dir (handles `../` and `index.md`). Source `.md` links stay relative, so GitHub raw rendering is unaffected.

## Verification

Full clean build (`rm -rf node_modules/.astro` first — Starlight caches parsed markdown in `data-store.json`), then a scan over `dist/`:

- **2,676** internal links — 0 broken
- **2,000** anchor fragments — 0 broken
- **50** per-page markdown twins + llms.txt — 0 missing
- copy-button `data-path` `.md` fetch targets — 0 broken

Merging triggers the `docs.yml` GitHub Pages deploy.