### PR TITLE
fix(compute): unblock fresh deploy on a clean AWS account (#229)

### DIFF
--- a/infrastructure/modules/compute/main.tf
+++ b/infrastructure/modules/compute/main.tf
@@ -179,6 +179,13 @@ resource "aws_iam_role_policy" "ecs_task_execution_secrets" {
         Resource = [
           "arn:aws:ssm:${var.aws_region}:${var.account_id}:parameter/ai-gateway/*"
         ]
+      },
+      {
+        # Secrets are encrypted with a customer-managed CMK; the ECS agent must
+        # be able to decrypt them when injecting container `secrets`.
+        Effect   = "Allow"
+        Action   = ["kms:Decrypt"]
+        Resource = [aws_kms_key.secrets.arn]
       }
     ]
   })
@@ -362,7 +369,16 @@ module "ecs_service" {
       cpu       = local.gateway_cpu
       memory    = local.gateway_memory
 
-      port_mappings = [{
+      # Keep the root filesystem read-only; Portkey only needs a writable /tmp,
+      # provided by the ephemeral `gateway-tmp` task volume mounted below.
+      readonlyRootFilesystem = true
+      mountPoints = [{
+        sourceVolume  = "gateway-tmp"
+        containerPath = "/tmp"
+        readOnly      = false
+      }]
+
+      portMappings = [{
         containerPort = 8787
         protocol      = "tcp"
       }]
@@ -395,7 +411,7 @@ module "ecs_service" {
         { name = "AZURE_API_KEY", valueFrom = aws_secretsmanager_secret.secrets["azure"].arn },
       ]
 
-      health_check = {
+      healthCheck = {
         command     = ["CMD-SHELL", "wget -q --spider http://localhost:8787/ || exit 1"]
         interval    = 15
         timeout     = 5
@@ -403,7 +419,11 @@ module "ecs_service" {
         startPeriod = 30
       }
 
-      log_configuration = {
+      # Log group is pre-created by the observability module; disable the
+      # module's auto-creation so it reuses ours instead of erroring.
+      enable_cloudwatch_logging   = false
+      create_cloudwatch_log_group = false
+      logConfiguration = {
         logDriver = "awslogs"
         options = {
           "awslogs-group"         = var.gateway_log_group_name
@@ -419,11 +439,25 @@ module "ecs_service" {
       cpu       = 256
       memory    = 256
 
+      # ADOT writes its working files under /tmp; keep the root FS read-only
+      # and back /tmp with an ephemeral task volume.
+      readonlyRootFilesystem = true
+      mountPoints = [{
+        sourceVolume  = "otel-tmp"
+        containerPath = "/tmp"
+        readOnly      = false
+      }]
+
       environment = [
         { name = "AOT_CONFIG_CONTENT", value = var.otel_config_content },
+        # ADOT config references ${env:AWS_REGION} for every AWS exporter; the
+        # ECS agent does not inject it automatically, so set it explicitly.
+        { name = "AWS_REGION", value = var.aws_region },
       ]
 
-      log_configuration = {
+      enable_cloudwatch_logging   = false
+      create_cloudwatch_log_group = false
+      logConfiguration = {
         logDriver = "awslogs"
         options = {
           "awslogs-group"         = var.otel_log_group_name
@@ -434,15 +468,23 @@ module "ecs_service" {
     }
   }
 
+  # Ephemeral writable scratch volumes so containers can keep a read-only root
+  # filesystem while still writing to /tmp. Fargate does not support
+  # linuxParameters.tmpfs, so we use empty task volumes instead.
+  volume = {
+    gateway-tmp = {}
+    otel-tmp    = {}
+  }
+
   # Network
   subnet_ids = var.private_subnets
 
   security_group_ingress_rules = {
     alb = {
-      from_port                = 8787
-      to_port                  = 8787
-      ip_protocol              = "tcp"
-      source_security_group_id = var.alb_security_group_id
+      from_port                    = 8787
+      to_port                      = 8787
+      ip_protocol                  = "tcp"
+      referenced_security_group_id = var.alb_security_group_id
     }
   }
 

--- a/infrastructure/otel-config.yaml
+++ b/infrastructure/otel-config.yaml
@@ -83,6 +83,7 @@ exporters:
   awscloudwatchlogs:
     region: ${env:AWS_REGION}
     log_group_name: /ecs/ai-gateway/otel-logs
+    log_stream_name: otel-collector
 
 service:
   pipelines:


### PR DESCRIPTION
Closes #229.

A `terraform apply` from `main` into an empty account never reaches a running gateway — the ECS deployment circuit breaker trips and rolls back. Six issues in `modules/compute/main.tf` (plus one OTel exporter setting in `otel-config.yaml`) caused it.

### Root cause (container issues)

The `terraform-aws-modules/ecs` v7.5.0 `container_definitions` input is a strict `map(object({...}))` with **camelCase** keys. HCL silently drops unknown attributes during type conversion, so the repo's snake_case keys evaporated:

```
port_mappings = [...]   ->   portMappings = null   # ECS: "container gateway did not have a container port 8787 defined"
```

I verified this directly: feeding `port_mappings` through the object type yields `portMappings = tolist(null)`.

### Fixes

| # | Issue | Fix |
|---|-------|-----|
| 1 | `port_mappings` dropped → no port 8787 | `port_mappings` → `portMappings`. **Also** `health_check` → `healthCheck` and `log_configuration` → `logConfiguration` on both containers — same silent-drop bug, not in the original report |
| 2 | `source_security_group_id` invalid on SG rule | → `referenced_security_group_id` (the only accepted key) |
| 3 | Exec role can't decrypt secrets | add `kms:Decrypt` on the Secrets Manager CMK to the task execution role |
| 4 | OTel container exits 1 silently | set `AWS_REGION` env — the ADOT config interpolates `${env:AWS_REGION}` for every AWS exporter and the agent doesn't inject it |
| 5 | `awscloudwatchlogs` exporter invalid config | set `log_stream_name` in `otel-config.yaml` |
| 6 | `readonlyRootFilesystem` blocks `/tmp` writes | **keep** `readonlyRootFilesystem = true` (security control preserved); add ephemeral task volumes (`gateway-tmp`, `otel-tmp`) + `mountPoints` for `/tmp`. Fargate doesn't support `linuxParameters.tmpfs`, so empty task volumes are the correct path |

### Validation

- `terraform fmt` + `terraform validate` pass.
- Local pre-commit gates pass: terraform-fmt, terraform-docs, gitleaks, terraform-validate, conventional-commit.
- Local pre-push gates pass: **iac (checkov 187/0)**, sast (semgrep), test (pytest).
- Rendered the real `container-definition` submodule standalone — confirmed `portMappings`/`8787`, `mountPoints`, `readonlyRootFilesystem`, `healthCheck`, and `logConfiguration` all flow through to the task definition JSON.

### Note

The local pre-push `trivy-fs` hook flags 2 pre-existing HIGH CVEs in `docs/pnpm-lock.yaml` (astro 6.4.2→6.4.6, vite 7.3.2→7.3.5) — unrelated to this Terraform-only diff and out of scope here. CI's trivy step is `continue-on-error` / non-blocking. Worth a separate `deps(docs)` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)