### PR TITLE
fix(ci): rescan detector must not read a scanner crash as a HIGH+ finding

### DIFF
--- a/.github/workflows/rescan-on-advisory.yml
+++ b/.github/workflows/rescan-on-advisory.yml
@@ -114,11 +114,54 @@ jobs:
           sarif_file: osv-results.sarif
           category: osv-scanner-rescan
 
+      # Parse SARIF result counts rather than trusting the scanner step
+      # outcomes. Grype/OSV exit non-zero both on a real finding and on a tool
+      # crash; counting SARIF results distinguishes the two so a scanner error
+      # no longer opens a false-positive issue. A missing SARIF is surfaced as
+      # an infra warning, not a finding.
+      #
+      # Per-scanner logic (each preserves that scanner's configured threshold):
+      #   • Grype runs with severity-cutoff: high, so only HIGH+ should trip the
+      #     alert. Grype writes rejected/detail-less records (e.g. CVE-2026-6791,
+      #     security-severity 0.0) into the SARIF regardless, so we filter on
+      #     GitHub's security-severity (>= 7.0 == HIGH), the HIGH/CRITICAL tags,
+      #     or an error-level result — a naive result count would false-positive.
+      #   • OSV has no cutoff configured and alerts on any lockfile vulnerability
+      #     by design, so we count all of its results.
       - name: Check for findings
         id: check-findings
         if: always()
+        env:
+          GRYPE_SARIF: ${{ steps.grype.outputs.sarif }}
         run: |
-          if [[ "${{ steps.grype.outcome }}" == "failure" || "${{ steps.osv.outcome }}" == "failure" ]]; then
+          count=0
+          # Grype — HIGH+ only (matches severity-cutoff: high)
+          if [[ -n "$GRYPE_SARIF" && -f "$GRYPE_SARIF" ]]; then
+            g=$(jq '[ .runs[]?
+              | ( [ .tool.driver.rules[]? | {key:.id, value:.} ] | from_entries ) as $rmap
+              | .results[]?
+              | .ruleId as $rid
+              | ($rmap[$rid].properties["security-severity"] // "0") as $ssev
+              | ($rmap[$rid].properties.tags // []) as $tags
+              | select( (($ssev | tonumber? // 0) >= 7.0)
+                        or ($tags | index("HIGH")) or ($tags | index("CRITICAL"))
+                        or (.level == "error") )
+            ] | length' "$GRYPE_SARIF")
+            echo "Grype HIGH+ results: ${g}"
+            count=$((count + g))
+          else
+            echo "::warning::Grype SARIF missing (scanner error, not a vulnerability finding)"
+          fi
+          # OSV — any lockfile vulnerability (no cutoff configured)
+          if [[ -f osv-results.sarif ]]; then
+            o=$(jq '[.runs[]?.results[]?] | length' osv-results.sarif)
+            echo "OSV results: ${o}"
+            count=$((count + o))
+          else
+            echo "::warning::OSV SARIF missing (scanner error, not a vulnerability finding)"
+          fi
+          echo "Total SBOM finding count: ${count}"
+          if [[ "${count}" -gt 0 ]]; then
             echo "found=true" >> "$GITHUB_OUTPUT"
           else
             echo "found=false" >> "$GITHUB_OUTPUT"
@@ -157,6 +200,7 @@ jobs:
       - name: Trivy rescan
         id: trivy
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+        continue-on-error: true   # a scanner crash must not be read as a finding; check-findings parses the SARIF result count instead
         with:
           image-ref: ai-gateway:rescan
           format: sarif
@@ -164,6 +208,7 @@ jobs:
           severity: CRITICAL,HIGH
           exit-code: "1"
           ignore-unfixed: true
+          trivyignores: .trivyignore
 
       - name: Upload Trivy SARIF
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
@@ -173,11 +218,38 @@ jobs:
           sarif_file: trivy-rescan-results.sarif
           category: trivy-rescan
 
+      # Count HIGH/CRITICAL results in the SARIF rather than trusting
+      # steps.trivy.outcome. Trivy exits non-zero both when it finds a
+      # HIGH/CRITICAL *and* when it crashes on a rejected/detail-less CVE record
+      # (e.g. CVE-2026-6791 in the Wolfi feed). The old logic conflated the two
+      # and opened a false-positive issue on every crash. Trivy also writes the
+      # crashing UNKNOWN record into the SARIF despite `severity: CRITICAL,HIGH`,
+      # so a naive result count is not enough — we filter on GitHub's
+      # security-severity (>= 7.0 == HIGH), the HIGH/CRITICAL SARIF tags, or an
+      # error-level result.
       - name: Check for findings
         id: check-findings
         if: always()
         run: |
-          if [[ "${{ steps.trivy.outcome }}" == "failure" ]]; then
+          if [[ ! -f trivy-rescan-results.sarif ]]; then
+            # No SARIF written at all — surface it as an infra warning, not a
+            # vulnerability finding, so a genuinely broken scan is not silently green.
+            echo "::warning::Trivy produced no SARIF output (scanner error, not a vulnerability finding)"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          count=$(jq '[ .runs[]?
+            | ( [ .tool.driver.rules[]? | {key:.id, value:.} ] | from_entries ) as $rmap
+            | .results[]?
+            | .ruleId as $rid
+            | ($rmap[$rid].properties["security-severity"] // "0") as $ssev
+            | ($rmap[$rid].properties.tags // []) as $tags
+            | select( (($ssev | tonumber? // 0) >= 7.0)
+                      or ($tags | index("HIGH")) or ($tags | index("CRITICAL"))
+                      or (.level == "error") )
+          ] | length' trivy-rescan-results.sarif)
+          echo "Trivy HIGH+ SARIF result count: ${count}"
+          if [[ "${count}" -gt 0 ]]; then
             echo "found=true" >> "$GITHUB_OUTPUT"
           else
             echo "found=false" >> "$GITHUB_OUTPUT"

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,14 @@
+# Trivy vulnerability ignore list
+# ────────────────────────────────────────────────────────────────
+# CVE-2026-6791 — glibc / glibc-locale-posix / ld-linux (Wolfi base).
+# This is a rejected / detail-less advisory record: Trivy's DB has the
+# ID present in the Wolfi feed but no vulnerability details, so newer
+# Trivy versions abort the scan with
+#   WARN "Unable to get vulnerability details (CVE may be rejected)"
+# and exit non-zero on the ERROR path — not because a HIGH/CRITICAL was
+# found. Ground-truth scan of the pinned agentgateway digest reports
+# Total: 0 (HIGH: 0, CRITICAL: 0). Suppressing the rejected record so
+# Trivy exits cleanly. The upstream Wolfi package fix is 2.43-r10; this
+# entry can be removed once the base image ships that or the CVE record
+# is withdrawn from the DB.
+CVE-2026-6791


### PR DESCRIPTION
## Problem

The nightly **Rescan on Advisory** workflow fails at HEAD and auto-opened false-positive security issue #245 (\"new HIGH+ vulnerabilities found\"). It is **not** finding a real vulnerability.

Root cause: the Trivy image-rescan step **crashes** on `CVE-2026-6791` — a rejected / detail-less advisory record in the Wolfi feed that Trivy's DB has by ID but cannot enrich:

```
WARN  Unable to get vulnerability details (CVE may be rejected)  vuln_id="CVE-2026-6791"
##[error]Process completed with exit code 1.
```

Trivy exits non-zero on the **error** path, and `check-findings` read *any* non-zero Trivy outcome (`steps.trivy.outcome == 'failure'`) as \"HIGH+ found\", opening an issue. The sibling Grype+OSV SBOM job passes.

Ground-truth CI-parity scan of the pinned digest (`sha256:c3ce7b7…a2c4381`), same flags as CI (`--severity CRITICAL,HIGH --ignore-unfixed --exit-code 1`):

```
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)  → exit 0
```

There is **no live HIGH+**. `CVE-2026-6791` is UNKNOWN/LOW severity (fixed upstream in `2.43-r10`), below the gate.

## Fix

- **rescan-image:** mark the Trivy step `continue-on-error` and decide findings by counting **HIGH/CRITICAL** results in the SARIF (`security-severity >= 7.0`, the `HIGH`/`CRITICAL` SARIF tags, or an `error`-level result) instead of trusting the step outcome. Trivy writes the crashing UNKNOWN record into the SARIF *despite* `severity: CRITICAL,HIGH`, so a naive result count is not enough — it would still false-positive on the 3 UNKNOWN records.
- **rescan-sbom:** apply the same crash-vs-finding split. Grype (`severity-cutoff: high`) is filtered to HIGH+ (it leaks the same UNKNOWN record); OSV keeps counting all results since it has no cutoff and alerts on any lockfile vuln by design.
- **`.trivyignore`:** add `CVE-2026-6791` so the rejected record is dropped from the SARIF, clearing the stale UNKNOWN code-scanning alerts (#457–459). Removable once the base image ships `2.43-r10` or the CVE record is withdrawn.

## Verification (local, against the pinned agentgateway digest + real Grype/OSV SARIFs)

| Scenario | Expected | Result |
|---|---|---|
| Pinned image, CI-parity gate | exit 0 | ✅ `Total: 0 HIGH+`, exit 0 |
| Image `check-findings` on real crash SARIF (3 UNKNOWN) | `found=false` | ✅ HIGH+ count = 0 |
| Grype filter on clean image (3 UNKNOWN) | 0 | ✅ 0 |
| Grype filter on deliberately-vulnerable image | >0 | ✅ 118 HIGH+ (no false negative) |
| OSV all-results count | unchanged | ✅ preserved |

Closes #245.