### PR TITLE
fix: resolve open issues #260-#263 (tier defaults, budget schema, checkov, CLI docs)

### DIFF
--- a/.checkov.yml
+++ b/.checkov.yml
@@ -32,3 +32,20 @@ skip-check:
   - CKV2_AWS_31  # WAF logging configured via aws_wafv2_web_acl_logging_configuration
   - CKV2_AWS_40  # scoped jsonencode policies — checkov misreads count-indexed ARNs as full IAM
   - CKV2_AWS_56  # no AWS-managed IAMFullAccess attached; policies are inline + scoped
+  # Terraform module sourcing — all first-party modules are local ./modules/*
+  # paths (commit-hash pinning is inapplicable); the only remote sources are
+  # terraform-aws-modules (vpc/alb/ecs) pinned to exact registry versions.
+  - CKV_TF_1     # local module sources + registry modules pinned to exact versions
+  # Lambda hardening — accepted risks for this serverless control-plane
+  # architecture. The 4 aws_lambda_function_url resources (routing_config,
+  # budget_enforcement, budget_admin_api, team_registration) all set
+  # authorization_type=AWS_IAM, never NONE. Reserved concurrency, DLQ, VPC
+  # placement, and code-signing are accepted-not-configured for these
+  # synchronously-invoked control-plane functions; only the async-invoked
+  # audit pipeline would materially benefit from a DLQ (pre_token already has
+  # one via aws_sqs_queue.lambda_dlq) — tracked for a follow-up, not this waiver.
+  - CKV2_AWS_50  # all function URLs use authorization_type=AWS_IAM (not NONE)
+  - CKV_AWS_115  # reserved concurrency accepted-default (only pre_token caps it at 10)
+  - CKV_AWS_116  # DLQ accepted for sync control-plane; async audit pipeline is the follow-up
+  - CKV_AWS_117  # Lambdas call AWS APIs + Bedrock over the AWS network; no VPC (avoids NAT)
+  - CKV_AWS_272  # code-signing not configured; deploy artifacts are built in-pipeline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,7 +338,7 @@ jobs:
           output_format: sarif
           output_file_path: checkov-results.sarif
           soft_fail: false
-          skip_check: CKV_TF_1,CKV2_AWS_50,CKV_AWS_115,CKV_AWS_116,CKV_AWS_117,CKV_AWS_272,CKV2_AWS_53,CKV2_AWS_51,CKV2_AWS_62,CKV_AWS_144,CKV_AWS_145,CKV_AWS_18,CKV_AWS_21,CKV2_AWS_29,CKV2_AWS_77,CKV2_AWS_4,CKV_AWS_276,CKV_AWS_225,CKV_AWS_308,CKV2_AWS_75,CKV2_AWS_57,CKV2_AWS_6,CKV_AWS_19,CKV_AWS_20,CKV_AWS_57,CKV2_AWS_31,CKV2_AWS_40,CKV2_AWS_56
+          config_file: .checkov.yml
           download_external_modules: false
 
       - name: Upload Checkov SARIF

--- a/engineering-docs/README.md
+++ b/engineering-docs/README.md
@@ -13,6 +13,7 @@ For getting-started, admin, and reference guides, see the published Starlight si
 ## Reference
 
 - [Public API](reference/public-api.md) — the importable `gwcore` surface plus the control-plane HTTP routes.
+- [CLI reference](reference/cli.md) — the `admin-cli` operator tool: command tree, Cognito M2M auth, and the admin route each verb calls.
 
 ## Behavior
 
@@ -35,9 +36,9 @@ For getting-started, admin, and reference guides, see the published Starlight si
 
 ## What this tree deliberately omits
 
-Five candidate documents were skipped because their subject does not exist here or the signal would mislead:
+Four candidate documents were skipped because their subject does not exist here or the signal would mislead:
 
-- **CLI reference** and **RPC/tools reference** — the repo is server-only (Lambda handlers + an agentgateway data plane); there is no CLI with subcommands and no RPC/MCP tool server.
+- **RPC/tools reference** — the runtime is server-only (Lambda handlers + an agentgateway data plane); there is no RPC/MCP tool server to document. (A CLI reference was originally skipped for the same reason, but a standalone operator CLI does exist under `clients/admin_cli/`, so it is now documented at [reference/cli.md](reference/cli.md).)
 - **Ownership**, **risk hotspots**, and **dead-code** analysis — git history is effectively single-author plus bots, and the services are Lambda entry points that nothing imports, so naive authorship, churn, and unreferenced-export signals produce false conclusions rather than useful ones.
 
 ## Notable findings surfaced during generation

--- a/engineering-docs/reference/cli.md
+++ b/engineering-docs/reference/cli.md
@@ -1,0 +1,153 @@
+# ai-gateway · CLI reference
+
+The repository ships one command-line tool: **`admin-cli`**, a thin operator client for the AI Gateway control plane, kept as a standalone `uv` project under `clients/admin_cli/`. It is not part of the Lambda runtime — it has its own `pyproject.toml`, does not import the gateway `src/` code, and does not reimplement the server Pydantic models. It forwards JSON bodies to the admin REST API and prints the parsed response envelope. `clients/admin_cli/admin_cli/__init__.py:1` The design is deliberate: a CLI before a UI, validating the API contract a future admin UI will consume. `clients/admin_cli/README.md:10`
+
+Operators here are the engineers who run the gateway internally for their own org's teams — the CLI administers the teams, budgets, routing configs, and pricing overrides those teams are governed by. It is built on [cyclopts](https://cyclopts.readthedocs.io/) (the command tree) and [httpx](https://www.python-httpx.org/) (HTTP + Cognito M2M auth). `clients/admin_cli/pyproject.toml:7`
+
+The command tree maps 1:1 onto the control-plane admin routes documented in [reference/public-api](public-api.md); every verb below is cross-linked to the handler that serves it.
+
+## Installation & entry point
+
+The console script `admin-cli` is registered against `admin_cli.__main__:app.meta` — the meta-app, which carries the global `--json` flag and the clean-error handler. `clients/admin_cli/pyproject.toml:12` The same target is reachable as `python -m admin_cli`; `__main__.py` re-exports `app`/`main` and calls `main()` under `__main__`. `clients/admin_cli/admin_cli/__main__.py:15` Python 3.13+ is required. `clients/admin_cli/pyproject.toml:6`
+
+```bash
+cd clients/admin_cli
+uv sync
+uv run admin-cli --help
+uv run admin-cli teams --help
+```
+
+`main()` calls `app.meta()`, which — per cyclopts' default `result_action` — raises `SystemExit` with the launcher's return code rather than returning; callers must not wrap it in another `sys.exit`. `clients/admin_cli/admin_cli/commands.py:299`
+
+## Authentication
+
+The CLI authenticates as a Cognito **machine-to-machine** client using the OAuth `client_credentials` grant. On its first call it POSTs `grant_type=client_credentials&scope=<admin scope>` to the Cognito token endpoint with `Authorization: Basic base64(client_id:client_secret)`, caches the access token in-memory for the process (Cognito TTL 3600s), attaches it as `Authorization: Bearer …` on each admin-API call, and — on a `401` — drops the token, re-fetches once, and retries the request exactly once. `clients/admin_cli/admin_cli/client.py:171` `clients/admin_cli/admin_cli/client.py:200`
+
+The requested scope defaults to `https://gateway.internal/admin` (`DEFAULT_ADMIN_SCOPE`), the same canonical admin scope the control plane enforces (`gwcore` `ADMIN_SCOPE`, see [reference/public-api](public-api.md)). `clients/admin_cli/admin_cli/client.py:32` The client credentials **must** hold this admin scope: team clients are provisioned with `invoke` only and receive `403 forbidden` from every admin endpoint, so they cannot drive this CLI. `clients/admin_cli/README.md:42`
+
+### Configuration (env vars)
+
+Nothing is hardcoded — connection and credential values come from the environment, each with an equivalent flag that wins over the env var. Resolution and the "which var is missing" error message live in `Config.from_env`. `clients/admin_cli/admin_cli/client.py:83`
+
+| Env var | Required | Purpose |
+|---|---|---|
+| `GATEWAY_ADMIN_URL` | yes | Admin REST API stage invoke URL, e.g. `https://{api_id}.execute-api.{region}.amazonaws.com/{env}` (Terraform `admin_api` output `api_url`). |
+| `GATEWAY_CLIENT_ID` | yes | Cognito M2M client id (an admin-scoped client). |
+| `GATEWAY_CLIENT_SECRET` | yes | Cognito M2M client secret. |
+| `GATEWAY_TOKEN_ENDPOINT` | yes\* | Full Cognito token URL: `https://{domain}.auth.{region}.amazoncognito.com/oauth2/token`. |
+| `COGNITO_DOMAIN` + `AWS_REGION` | yes\* | Alternative to `GATEWAY_TOKEN_ENDPOINT`: the endpoint is derived from these (`AWS_DEFAULT_REGION` also accepted). |
+| `GATEWAY_ADMIN_SCOPE` | no | Override the requested scope (default `https://gateway.internal/admin`). |
+
+\* Provide **either** `GATEWAY_TOKEN_ENDPOINT` **or** `COGNITO_DOMAIN` + `AWS_REGION`; the endpoint is derived from the latter pair when the explicit URL is absent. `clients/admin_cli/admin_cli/client.py:74` A trailing slash on `GATEWAY_ADMIN_URL` is stripped. `clients/admin_cli/admin_cli/client.py:124` When any required value is missing, the CLI exits non-zero with a `config_error` naming the missing var — never a stack trace. `clients/admin_cli/admin_cli/client.py:119`
+
+## Global flags & output
+
+The meta-app exposes one global flag, `--json`, which emits raw compact JSON (`{"a":1}`) instead of the default pretty-printed, key-sorted output. `clients/admin_cli/admin_cli/commands.py:274` It precedes the sub-app on the command line (e.g. `admin-cli --json teams list`). Output goes to stdout via `_print`; an empty response body (e.g. a `204`) prints nothing. `clients/admin_cli/admin_cli/commands.py:116`
+
+Mutating commands accept a request body through two combinable flags, built by `build_body`: `clients/admin_cli/admin_cli/commands.py:79`
+
+- `--body` / `-b` — inline JSON, or `@path/to/file.json` to read the body from a file.
+- `--set` / `-s` — set a top-level field as `key=value` (repeatable). The value is parsed as JSON when it parses (`1000` → int, `true` → bool), else kept as a string; `--set` overlays fields on top of `--body`.
+
+The CLI does not validate the body — the server owns the schema and returns a `validation_failed` error envelope if it is wrong. `clients/admin_cli/README.md:76`
+
+## Command reference
+
+Each sub-app is registered on the root app; each verb is a cyclopts command whose docstring names the HTTP method and path it calls. `clients/admin_cli/admin_cli/commands.py:62` Positional arguments below are path segments; `--body`/`--set` apply to the create/update/upsert verbs.
+
+### `teams` — team registration
+
+`clients/admin_cli/admin_cli/commands.py:58`
+
+| Command | Positional args | Body | HTTP call | Handler |
+|---|---|---|---|---|
+| `teams list` | — | — | `GET /teams` | `src/team_registration/handler.py:56` |
+| `teams get <team_id>` | `team_id` | — | `GET /teams/{id}` | `src/team_registration/handler.py:58` |
+| `teams create` | — | `--body` / `--set` (team_name, contact_email, tier, description) | `POST /teams` | `src/team_registration/handler.py:54` |
+| `teams rotate <team_id>` | `team_id` | — | `POST /teams/{id}/rotate` | `src/team_registration/handler.py:60` |
+| `teams delete <team_id>` | `team_id` | — | `DELETE /teams/{id}` | `src/team_registration/handler.py:62` |
+
+`teams create` registers a team (creates a Cognito client, stores metadata, seeds a budget); `teams rotate` rotates the team's Cognito client credentials; `teams delete` deactivates the team and deletes its Cognito client, revoking its tokens. `clients/admin_cli/admin_cli/commands.py:146`
+
+### `budgets` — budgets (paginated)
+
+`clients/admin_cli/admin_cli/commands.py:59`
+
+| Command | Positional args | Options / body | HTTP call | Handler |
+|---|---|---|---|---|
+| `budgets list` | — | `--cursor <C>` (opaque `next_cursor` from a prior list) | `GET /budgets` | `src/budget_admin/handler.py:90` |
+| `budgets get <budget_id>` | `budget_id` | — | `GET /budgets/{id}` | `src/budget_admin/handler.py:112` |
+| `budgets create` | — | `--body` / `--set` (scope, scope_id, budget_usd, …) | `POST /budgets` | `src/budget_admin/handler.py:93` |
+| `budgets update <budget_id>` | `budget_id` | `--body` / `--set` (budget_usd, period, …) | `PUT /budgets/{id}` | `src/budget_admin/handler.py:114` |
+| `budgets delete <budget_id>` | `budget_id` | — | `DELETE /budgets/{id}` | `src/budget_admin/handler.py:116` |
+
+`budgets list` is cursor-paginated: the `--cursor` value is passed as the `cursor` query param and is dropped when `None`, so an empty cursor is omitted. `clients/admin_cli/admin_cli/commands.py:179` `clients/admin_cli/admin_cli/client.py:241`
+
+### `routing` — routing configs
+
+`clients/admin_cli/admin_cli/commands.py:60`
+
+| Command | Positional args | Body | HTTP call | Handler |
+|---|---|---|---|---|
+| `routing list` | — | — | `GET /routing/configs` | `src/routing_config/handler.py:284` |
+| `routing get <name>` | `name` | — | `GET /routing/configs/{name}` | `src/routing_config/handler.py:286` |
+| `routing create` | — | `--body` / `--set` (strategy, targets, metadata) | `POST /routing/configs` | `src/routing_config/handler.py:288` |
+| `routing update <name>` | `name` | `--body` / `--set` | `PUT /routing/configs/{name}` | `src/routing_config/handler.py:290` |
+| `routing delete <name>` | `name` | — | `DELETE /routing/configs/{name}` | `src/routing_config/handler.py:292` |
+
+`clients/admin_cli/admin_cli/commands.py:212`
+
+### `pricing` — pricing overrides
+
+`clients/admin_cli/admin_cli/commands.py:61`
+
+| Command | Positional args | Body | HTTP call | Handler |
+|---|---|---|---|---|
+| `pricing list` | — | — | `GET /pricing` | `src/pricing_admin/handler.py:260` |
+| `pricing get <provider> <model>` | `provider`, `model` | — | `GET /pricing/{provider}/{model}` | `src/pricing_admin/handler.py:262` |
+| `pricing upsert <provider> <model>` | `provider`, `model` | `--body` / `--set` (input_per_1k, …) | `PUT /pricing/{provider}/{model}` | `src/pricing_admin/handler.py:264` |
+| `pricing delete <provider> <model>` | `provider`, `model` | — | `DELETE /pricing/{provider}/{model}` | `src/pricing_admin/handler.py:266` |
+
+`pricing list` returns the DynamoDB overrides merged over the static pricing table; `pricing delete` reports whether a static fallback price remains. `clients/admin_cli/admin_cli/commands.py:245`
+
+## Errors & exit codes
+
+The response envelope is parsed by the client: a success body is returned as a dict (empty body → `None`), while a 4xx/5xx maps the gateway error envelope `{"error": {"code", "message", details?}}` to a `GatewayError`. `clients/admin_cli/admin_cli/client.py:263` The meta-app launcher catches `GatewayError` and prints a readable one-liner — `error: <code>: <message>` (plus ` (details)` when present) — to stderr, returning exit code `1`; a successful run returns `0`. `clients/admin_cli/admin_cli/commands.py:290` No stack trace is printed for a config, auth, or API error. The error `code` is the same stable machine-readable code the control plane emits (`config_error`, `token_error`, `body_error` locally; `validation_failed`, `not_found`, `conflict`, `forbidden`, `upstream_error`, etc. from the server — see the `ControlPlaneError` hierarchy in [reference/public-api](public-api.md)).
+
+## Examples
+
+```bash
+# Configure once (M2M admin client + Cognito domain)
+export GATEWAY_ADMIN_URL="https://abc123.execute-api.us-east-1.amazonaws.com/prod"
+export GATEWAY_CLIENT_ID="…"  GATEWAY_CLIENT_SECRET="…"
+export COGNITO_DOMAIN="my-gateway"  AWS_REGION="us-east-1"
+
+# Register a team with inline --set fields (POST /teams)
+uv run admin-cli teams create \
+  --set team_name=payments-svc \
+  --set contact_email=payments@example.com \
+  --set tier=premium
+
+# Create a budget from a file, then page through budgets
+uv run admin-cli budgets create --body @budget.json
+uv run admin-cli budgets list --cursor "<next_cursor from a prior list>"
+
+# Upsert a pricing override, raw compact JSON output (--json is global, precedes the sub-app)
+uv run admin-cli --json pricing upsert bedrock claude-sonnet-4 \
+  --set input_per_1k=0.003 --set output_per_1k=0.015
+
+# Rotate a team's credentials (POST /teams/{id}/rotate)
+uv run admin-cli teams rotate team-123
+```
+
+## Testing
+
+The CLI is tested with no live network or AWS: `tests/test_client.py` uses stdlib `httpx.MockTransport` to serve both the Cognito token endpoint and the admin API, covering token acquisition, envelope parsing, the 401→refresh→retry path, and the error-envelope → `GatewayError` mapping. `clients/admin_cli/tests/test_client.py:34` `tests/test_commands.py` drives the cyclopts command tree with token lists and stubs `_client`, asserting each verb's method/path/body/params and the non-zero exit on a `GatewayError`. `clients/admin_cli/tests/test_commands.py:108`
+
+## See also
+
+- [reference/public-api](public-api.md) — the control-plane HTTP routes every command calls, and the `gwcore` `ADMIN_SCOPE` / `ControlPlaneError` surface the CLI mirrors.
+- [insights/contract-map](../insights/contract-map.md) — the HTTP response and error envelopes the CLI parses.
+- [architecture/module-map](../architecture/module-map.md) — the `src/` service packages behind each admin route.
+</content>
+</invoke>

--- a/engineering-docs/reference/public-api.md
+++ b/engineering-docs/reference/public-api.md
@@ -1,6 +1,6 @@
 # ai-gateway · Public API
 
-The importable public surface of `ai-gateway` is the shared `gwcore` package — the authentication, error, response, audit, cache, telemetry, logging, and agentgateway-contract helpers that every control-plane and data-plane Lambda imports. The 30 symbols below are the `gwcore` exports ranked by inbound-reference count from the eleven service packages under `src/` (tie-broken alphabetically). The repository ships no CLI (no `argparse`, `console_scripts`, or `__main__` entry point), so the HTTP surface of the Lambda services is enumerated in the final `## HTTP` section.
+The importable public surface of `ai-gateway` is the shared `gwcore` package — the authentication, error, response, audit, cache, telemetry, logging, and agentgateway-contract helpers that every control-plane and data-plane Lambda imports. The 30 symbols below are the `gwcore` exports ranked by inbound-reference count from the eleven service packages under `src/` (tie-broken alphabetically). This doc covers that importable `gwcore` surface plus the Lambda services' HTTP surface (enumerated in the final `## HTTP` section). The repository also ships a standalone operator CLI, `admin-cli`, under `clients/admin_cli/` (a separate `uv` project that does not import `gwcore`); it is documented in [reference/cli](cli.md).
 
 ### emit_metric
 

--- a/infrastructure/modules/budgets/enforcement.tf
+++ b/infrastructure/modules/budgets/enforcement.tf
@@ -133,10 +133,6 @@ resource "aws_lambda_function" "budget_enforcement" {
       USAGE_TABLE                 = var.usage_table
       TIER_DEFAULTS               = jsonencode(var.tier_defaults)
       BUDGET_ALERTS_SNS_TOPIC_ARN = var.enable_budgets ? aws_sns_topic.budget_alerts[0].arn : ""
-      TIER_DEFAULT_FREE           = var.tier_default_free
-      TIER_DEFAULT_STANDARD       = var.tier_default_standard
-      TIER_DEFAULT_PREMIUM        = var.tier_default_premium
-      TIER_DEFAULT_ENTERPRISE     = var.tier_default_enterprise
     }
   }
 

--- a/infrastructure/modules/budgets/variables.tf
+++ b/infrastructure/modules/budgets/variables.tf
@@ -50,26 +50,6 @@ variable "usage_table" {
   default     = "gateway-usage"
 }
 
-variable "tier_default_free" {
-  type    = string
-  default = "10"
-}
-
-variable "tier_default_standard" {
-  type    = string
-  default = "1000"
-}
-
-variable "tier_default_premium" {
-  type    = string
-  default = "10000"
-}
-
-variable "tier_default_enterprise" {
-  type    = string
-  default = "100000"
-}
-
 variable "tier_defaults" {
   description = "Tier defaults as a map of tier name to config (E.4)"
   type = map(object({
@@ -80,7 +60,7 @@ variable "tier_defaults" {
   default = {
     sandbox   = { rpm = 20, tokens_per_day = 100000, monthly_usd = 25 }
     standard  = { rpm = 100, tokens_per_day = 500000, monthly_usd = 100 }
-    premium   = { rpm = 500, tokens_per_day = 5000000, monthly_usd = 1000 }
+    high      = { rpm = 500, tokens_per_day = 5000000, monthly_usd = 1000 }
     unlimited = { rpm = 2000, tokens_per_day = -1, monthly_usd = 10000 }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dev = [
     "pytest-cov>=7.1.0",
     "commitizen>=4.16.4",
     "bandit[sarif]>=1.9.4",
+    "moto>=5.2.2",
 ]
 
 [tool.uv]

--- a/src/budget_admin/models.py
+++ b/src/budget_admin/models.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from gwcore.tiers import Tier as TenantTier
+
 
 class BudgetScope(StrEnum):
     """Supported budget scopes."""
@@ -23,15 +25,6 @@ class BudgetPeriod(StrEnum):
     MONTHLY = "monthly"
     QUARTERLY = "quarterly"
     ANNUAL = "annual"
-
-
-class TenantTier(StrEnum):
-    """Supported tenant tiers."""
-
-    FREE = "free"
-    STANDARD = "standard"
-    PREMIUM = "premium"
-    ENTERPRISE = "enterprise"
 
 
 class ModelLimit(BaseModel):

--- a/src/budget_enforcement/handler.py
+++ b/src/budget_enforcement/handler.py
@@ -48,6 +48,7 @@ from budget_enforcement.models import (
 from gwcore import agentgateway, audit
 from gwcore.logging import bind, correlation_id, get_logger
 from gwcore.telemetry import Timer, emit_metric
+from gwcore.tiers import TIER_DEFAULTS as GWCORE_TIER_DEFAULTS
 from rate_limiter.handler import check_rate_limit
 
 logger = get_logger("budget_enforcement")
@@ -55,15 +56,16 @@ logger = get_logger("budget_enforcement")
 BUDGETS_TABLE = os.environ.get("BUDGETS_TABLE", "gateway-budgets")
 USAGE_TABLE = os.environ.get("USAGE_TABLE", "gateway-usage")
 
-# ── Tier defaults ────────────────────────────────────────────────────────────
-# E.4: Load tier defaults from TIER_DEFAULTS env var (JSON) or fall back to
-# legacy per-tier env vars for backward compatibility.
+# The budget's configured USD amount IS the hard cap (100%); admin has no
+# separate hard-limit percentage. Warn thresholds are the alert points below it.
+_HARD_LIMIT_PCT = 100
 
-_DEFAULT_TIER_DEFAULTS: dict[str, dict[str, Any]] = {
-    "sandbox": {"rpm": 20, "tokens_per_day": 100000, "monthly_usd": 25},
-    "standard": {"rpm": 100, "tokens_per_day": 500000, "monthly_usd": 100},
-    "premium": {"rpm": 500, "tokens_per_day": 5000000, "monthly_usd": 1000},
-    "unlimited": {"rpm": 2000, "tokens_per_day": -1, "monthly_usd": 10000},
+# ── Tier defaults ────────────────────────────────────────────────────────────
+# Tier defaults come from gwcore.tiers (the single source of truth, issue #260)
+# and can be overridden per-deployment via the TIER_DEFAULTS env var (JSON).
+
+_DEFAULT_TIER_DEFAULTS: dict[str, TierConfig] = {
+    t.value: TierConfig.model_validate(d) for t, d in GWCORE_TIER_DEFAULTS.items()
 }
 
 
@@ -78,29 +80,7 @@ def _load_tier_defaults() -> dict[str, TierConfig]:
         except (json.JSONDecodeError, ValidationError):
             logger.warning("Failed to parse TIER_DEFAULTS env var, using built-in defaults", exc_info=True)
 
-    # Legacy fallback: per-tier env vars (monthly_usd only)
-    legacy_free = os.environ.get("TIER_DEFAULT_FREE")
-    if legacy_free is not None:
-        return {
-            "free": TierConfig(rpm=20, tokens_per_day=100000, monthly_usd=Decimal(legacy_free)),
-            "standard": TierConfig(
-                rpm=100,
-                tokens_per_day=500000,
-                monthly_usd=Decimal(os.environ.get("TIER_DEFAULT_STANDARD", "1000")),
-            ),
-            "premium": TierConfig(
-                rpm=500,
-                tokens_per_day=5000000,
-                monthly_usd=Decimal(os.environ.get("TIER_DEFAULT_PREMIUM", "10000")),
-            ),
-            "enterprise": TierConfig(
-                rpm=2000,
-                tokens_per_day=-1,
-                monthly_usd=Decimal(os.environ.get("TIER_DEFAULT_ENTERPRISE", "100000")),
-            ),
-        }
-
-    return {k: TierConfig.model_validate(v) for k, v in _DEFAULT_TIER_DEFAULTS.items()}
+    return dict(_DEFAULT_TIER_DEFAULTS)
 
 
 TIER_DEFAULTS: dict[str, TierConfig] = _load_tier_defaults()
@@ -111,18 +91,93 @@ dynamodb = boto3.resource("dynamodb", region_name=os.environ.get("AWS_REGION", "
 # ── DynamoDB helpers ─────────────────────────────────────────────────────────
 
 
+def _budget_warn_pct(alert_thresholds: Any) -> float:
+    """Derive a warn threshold from budget_admin's ``alert_thresholds`` list.
+
+    Admin stores a list of percent ints (e.g. ``[50, 80, 100]``). We treat the
+    highest threshold that is strictly below 100 as the warn point (80 here);
+    100 is the hard cap, not a warning. Falls back to 80 when nothing qualifies.
+    """
+    if isinstance(alert_thresholds, (list, tuple)):
+        below_cap = [int(t) for t in alert_thresholds if _is_int_like(t) and int(t) < _HARD_LIMIT_PCT]
+        if below_cap:
+            return float(max(below_cap))
+    return 80.0
+
+
+def _is_int_like(value: Any) -> bool:
+    try:
+        int(value)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def _adapt_admin_budget(item: dict[str, Any]) -> dict[str, Any]:
+    """Translate a budget_admin-written item into the field vocabulary this
+    enforcement handler consumes.
+
+    budget_admin (src/budget_admin/routes.py::create_budget) and this handler
+    grew independent field names against the same ``gateway-budgets`` table
+    (issue #261). Rather than reshape the table or the admin write path (whose
+    keys are immutable / already correct), we adapt on read:
+
+    - ``monthly_budget_usd`` <- ``budget_usd`` (the admin-configured cap)
+    - ``warn_threshold_pct``  <- derived from ``alert_thresholds`` (highest < 100)
+    - ``hard_limit_pct``      <- 100 (admin has no separate hard limit; the
+      configured ``budget_usd`` IS the hard cap)
+    - ``rpm`` / ``tokens_per_day`` are intentionally NOT synthesized: they are
+      absent on the admin item, so the consumer falls back to tier_config.
+    - ``model_limits`` is passed through unchanged; ``_parse_model_limits``
+      accepts both the admin list form and the legacy dict form.
+    """
+    adapted = dict(item)
+    if "budget_usd" in item and "monthly_budget_usd" not in item:
+        adapted["monthly_budget_usd"] = item["budget_usd"]
+    adapted.setdefault("warn_threshold_pct", _budget_warn_pct(item.get("alert_thresholds")))
+    adapted.setdefault("hard_limit_pct", _HARD_LIMIT_PCT)
+    return adapted
+
+
 def _get_budget_record(team: str) -> dict[str, Any] | None:
-    """Fetch the budget configuration for a team from DynamoDB."""
+    """Fetch the team-scoped budget configuration from DynamoDB (issue #261).
+
+    Budgets are written by budget_admin keyed by ``budget_id`` (uuid) + ``scope``
+    ("CONFIG"), with the entity id in ``scope_id`` and the entity kind in
+    ``scope_type``. Enforcement looks a budget up by *team*, so we query the
+    ``scope-index`` GSI (HASH=``scope``, RANGE=``scope_id``): every config item
+    shares the partition value "CONFIG", and the range key is ``scope_id``, so
+    ``scope == "CONFIG" AND scope_id == team`` returns the budgets for that
+    entity id. We filter for ``scope_type == "team"`` to select the team budget
+    (ignoring any user/project budget that happens to share the id) and return
+    the first match, adapted to this handler's field vocabulary.
+    """
+    from boto3.dynamodb.conditions import Attr, Key  # noqa: PLC0415
+
     table = dynamodb.Table(BUDGETS_TABLE)
-    resp = table.get_item(Key={"pk": f"BUDGET#{team}", "sk": "CONFIG"})
-    return resp.get("Item")
+    resp = table.query(
+        IndexName="scope-index",
+        KeyConditionExpression=Key("scope").eq("CONFIG") & Key("scope_id").eq(team),
+        FilterExpression=Attr("scope_type").eq("team"),
+    )
+    items = resp.get("Items", [])
+    if not items:
+        return None
+    return _adapt_admin_budget(items[0])
 
 
 def _get_current_usage(team: str) -> Decimal:
-    """Fetch the current-period spend for a team from DynamoDB."""
+    """Fetch the current-period spend for a team from DynamoDB.
+
+    Usage rows are keyed by the real Terraform schema (issue #261): the physical
+    ``gateway-usage`` table is hash=``scope_id``, range=``period_date`` (see
+    infrastructure/modules/budgets/main.tf). Team usage is written by
+    cost_attribution under ``scope_id = f"team#{team}"`` with a monthly
+    ``period_date`` of ``YYYY-MM`` — the same convention budget_admin reads.
+    """
     table = dynamodb.Table(USAGE_TABLE)
     period = datetime.now(tz=UTC).strftime("%Y-%m")
-    resp = table.get_item(Key={"pk": f"USAGE#TEAM#{team}", "sk": f"PERIOD#{period}"})
+    resp = table.get_item(Key={"scope_id": f"team#{team}", "period_date": period})
     item = resp.get("Item")
     if not item:
         return Decimal("0.00")
@@ -133,10 +188,15 @@ def _get_current_usage(team: str) -> Decimal:
 
 
 def _get_model_usage(team: str, model: str) -> Decimal:
-    """Fetch the current-period spend for a specific model within a team."""
+    """Fetch the current-period spend for a specific model within a team.
+
+    Per-model usage is written by cost_attribution under the conforming key
+    ``scope_id = f"team#{team}#model#{model}"``, ``period_date = YYYY-MM``
+    (issue #261, real ``gateway-usage`` schema).
+    """
     table = dynamodb.Table(USAGE_TABLE)
     period = datetime.now(tz=UTC).strftime("%Y-%m")
-    resp = table.get_item(Key={"pk": f"USAGE#TEAM#{team}#MODEL#{model}", "sk": f"PERIOD#{period}"})
+    resp = table.get_item(Key={"scope_id": f"team#{team}#model#{model}", "period_date": period})
     item = resp.get("Item")
     if not item:
         return Decimal("0.00")
@@ -159,17 +219,32 @@ def _seconds_until_period_reset() -> int:
 
 
 def _parse_model_limits(budget_item: dict[str, Any]) -> dict[str, ModelLimit]:
-    """Parse model_limits from a DynamoDB budget record."""
+    """Parse model_limits from a DynamoDB budget record.
+
+    Accepts BOTH shapes (issue #261), defensively:
+    - Legacy enforcement dict form: ``{model_name: {"monthly_usd": ..., ...}}``
+    - budget_admin list form: ``[{"model": name, "max_cost_usd": ...}, ...]``
+      where ``max_cost_usd`` maps onto ``ModelLimit.monthly_usd``.
+    """
     raw = budget_item.get("model_limits")
-    if not raw or not isinstance(raw, dict):
-        return {}
     result: dict[str, ModelLimit] = {}
-    for model_name, limit_data in raw.items():
-        try:
-            if isinstance(limit_data, dict):
+    if isinstance(raw, dict):
+        for model_name, limit_data in raw.items():
+            if not isinstance(limit_data, dict):
+                continue
+            try:
                 result[model_name] = ModelLimit.model_validate(limit_data)
-        except ValidationError:
-            logger.warning("Invalid model_limit for model=%s, skipping", model_name)
+            except ValidationError:
+                logger.warning("Invalid model_limit for model=%s, skipping", model_name)
+    elif isinstance(raw, list):
+        for entry in raw:
+            if not isinstance(entry, dict) or "model" not in entry:
+                continue
+            model_name = entry["model"]
+            try:
+                result[model_name] = ModelLimit.model_validate({"monthly_usd": entry.get("max_cost_usd", 0)})
+            except ValidationError:
+                logger.warning("Invalid model_limit for model=%s, skipping", model_name)
     return result
 
 

--- a/src/chargeback_report/handler.py
+++ b/src/chargeback_report/handler.py
@@ -42,24 +42,25 @@ s3 = boto3.client("s3", region_name=AWS_REGION)
 def _query_team_usage(month: str) -> list[dict[str, Any]]:
     """Query all team usage records for a given month from the usage table.
 
-    Scans for items where pk starts with USAGE#TEAM# and sk matches the
-    target period. Uses the period-index GSI for efficient lookups.
+    Reads the real ``gateway-usage`` schema (issue #261): hash=``scope_id``,
+    range=``period_date``. Team monthly rows are written by cost_attribution as
+    ``scope_id = "team#<team>"``, ``period_date = "YYYY-MM"``. We scan for
+    ``scope_id begins_with "team#"`` and ``period_date == month``, then EXCLUDE
+    per-model rows (``scope_id = "team#<team>#model#<model>"``) so per-team
+    chargeback totals do not double-count model-level usage.
     """
     table = dynamodb.Table(USAGE_TABLE)
-    period_sk = f"PERIOD#{month}"
+
+    filter_expr = Key("scope_id").begins_with("team#") & Key("period_date").eq(month)
 
     items: list[dict[str, Any]] = []
     try:
-        # Scan for team usage records matching the period
-        # Using scan with filter since we need all teams for a given period
-        response = table.scan(
-            FilterExpression=Key("sk").eq(period_sk) & Key("pk").begins_with("USAGE#TEAM#"),
-        )
+        response = table.scan(FilterExpression=filter_expr)
         items.extend(response.get("Items", []))
 
         while "LastEvaluatedKey" in response:
             response = table.scan(
-                FilterExpression=Key("sk").eq(period_sk) & Key("pk").begins_with("USAGE#TEAM#"),
+                FilterExpression=filter_expr,
                 ExclusiveStartKey=response["LastEvaluatedKey"],
             )
             items.extend(response.get("Items", []))
@@ -67,38 +68,46 @@ def _query_team_usage(month: str) -> list[dict[str, Any]]:
         logger.exception("Failed to query usage table for month %s", month)
         raise
 
-    logger.info("Found %d team usage records for %s", len(items), month)
-    return items
+    # Exclude per-model rows so per-team totals are not double-counted.
+    team_items = [item for item in items if "#model#" not in str(item.get("scope_id", ""))]
+
+    logger.info("Found %d team usage records for %s", len(team_items), month)
+    return team_items
 
 
 def _query_budget_limits() -> dict[str, Decimal]:
     """Query budget limits for all teams.
 
     Returns a mapping of team name to monthly budget limit in USD.
+
+    Budgets are written by budget_admin on the real ``gateway-budgets`` schema
+    (issue #261): config rows carry ``scope == "CONFIG"``, the entity kind in
+    ``scope_type`` and the entity id in ``scope_id``, with the cap in
+    ``budget_usd``. We scan for team-scoped config rows and index them by team.
     """
+    from boto3.dynamodb.conditions import Attr  # noqa: PLC0415
+
     table = dynamodb.Table(BUDGETS_TABLE)
     limits: dict[str, Decimal] = {}
+    filter_expr = Key("scope").eq("CONFIG") & Attr("scope_type").eq("team")
 
-    try:
-        response = table.scan(
-            FilterExpression=Key("scope").eq("team"),
-        )
-        for item in response.get("Items", []):
-            team = item.get("scope_id", item.get("team", ""))
-            budget = item.get("monthly_budget_usd", item.get("monthly_usd"))
+    def _absorb(items: list[dict[str, Any]]) -> None:
+        for item in items:
+            team = item.get("scope_id", "")
+            budget = item.get("budget_usd", item.get("monthly_budget_usd"))
             if team and budget is not None:
                 limits[team] = Decimal(str(budget))
 
+    try:
+        response = table.scan(FilterExpression=filter_expr)
+        _absorb(response.get("Items", []))
+
         while "LastEvaluatedKey" in response:
             response = table.scan(
-                FilterExpression=Key("scope").eq("team"),
+                FilterExpression=filter_expr,
                 ExclusiveStartKey=response["LastEvaluatedKey"],
             )
-            for item in response.get("Items", []):
-                team = item.get("scope_id", item.get("team", ""))
-                budget = item.get("monthly_budget_usd", item.get("monthly_usd"))
-                if team and budget is not None:
-                    limits[team] = Decimal(str(budget))
+            _absorb(response.get("Items", []))
     except Exception:
         logger.warning("Failed to query budget limits — proceeding without budget data", exc_info=True)
 
@@ -132,9 +141,9 @@ def _build_team_summaries(
     summaries: list[TeamUsageSummary] = []
 
     for item in usage_items:
-        pk: str = item.get("pk", "")
-        team = pk.removeprefix("USAGE#TEAM#")
-        if not team:
+        scope_id: str = item.get("scope_id", "")
+        team = scope_id.removeprefix("team#")
+        if not team or "#model#" in scope_id:
             continue
 
         total_cost = Decimal(str(item.get("total_cost_usd", 0)))

--- a/src/cost_attribution/handler.py
+++ b/src/cost_attribution/handler.py
@@ -288,11 +288,14 @@ def _publish_metrics(metrics: list[MetricResult]) -> None:
 def _accumulate_usage(metrics: list[MetricResult]) -> None:
     """Write usage increments to DynamoDB (best-effort).
 
-    Writes both team-level (``USAGE#TEAM#<team>``) and user-level
-    (``USAGE#USER#<user>``) rows using atomic ``ADD`` operations so
-    concurrent Lambda invocations never lose counts.
+    Rows are keyed by the real Terraform ``gateway-usage`` schema (issue #261):
+    hash=``scope_id``, range=``period_date`` (see
+    infrastructure/modules/budgets/main.tf), matching what budget_admin and
+    budget_enforcement read. Writes both team-level (``scope_id="team#<team>"``)
+    and user-level (``scope_id="user#<user>"``) rows using atomic ``ADD``
+    operations so concurrent Lambda invocations never lose counts.
 
-    Also writes per-model usage rows (``USAGE#TEAM#<team>#MODEL#<model>``)
+    Also writes per-model usage rows (``scope_id="team#<team>#model#<model>"``)
     to support E.5 model-level budget checks.
     """
     if not metrics:
@@ -341,7 +344,7 @@ def _accumulate_usage(metrics: list[MetricResult]) -> None:
         model_agg[model_key]["total_cost_usd"] = float(model_agg[model_key]["total_cost_usd"]) + m.cost_usd
         model_agg[model_key]["request_count"] += 1
 
-    def _update(pk: str, sk: str, vals: dict[str, int | float]) -> None:
+    def _update(scope_id: str, period_date: str, vals: dict[str, int | float]) -> None:
         expr_parts = []
         attr_vals: dict[str, Any] = {}
         field_map = {
@@ -359,27 +362,27 @@ def _accumulate_usage(metrics: list[MetricResult]) -> None:
                 attr_vals[placeholder] = Decimal(str(round(val, 10))) if field_name == "total_cost_usd" else val
 
         table.update_item(
-            Key={"pk": pk, "sk": sk},
+            Key={"scope_id": scope_id, "period_date": period_date},
             UpdateExpression="ADD " + ", ".join(expr_parts),
             ExpressionAttributeValues=attr_vals,
         )
 
     for team, vals in team_agg.items():
         try:
-            _update(f"USAGE#TEAM#{team}", f"PERIOD#{period}", vals)
+            _update(f"team#{team}", period, vals)
         except Exception:
             logger.warning("Failed to write team usage for %s", team, exc_info=True)
 
     for user, vals in user_agg.items():
         try:
-            _update(f"USAGE#USER#{user}", f"PERIOD#{period}", vals)
+            _update(f"user#{user}", period, vals)
         except Exception:
             logger.warning("Failed to write user usage for %s", user, exc_info=True)
 
     # E.5: Write model-level usage
     for (team, model), vals in model_agg.items():
         try:
-            _update(f"USAGE#TEAM#{team}#MODEL#{model}", f"PERIOD#{period}", vals)
+            _update(f"team#{team}#model#{model}", period, vals)
         except Exception:
             logger.warning("Failed to write model usage for team=%s model=%s", team, model, exc_info=True)
 
@@ -388,10 +391,27 @@ def _accumulate_usage(metrics: list[MetricResult]) -> None:
 
 
 def _get_budget_record(team: str) -> dict[str, Any] | None:
-    """Fetch the budget configuration for a team from DynamoDB."""
+    """Fetch the team-scoped budget configuration from DynamoDB (issue #261).
+
+    Budgets are written by budget_admin keyed by ``budget_id`` (uuid) + ``scope``
+    ("CONFIG"), with the entity id in ``scope_id`` and the entity kind in
+    ``scope_type``. The physical table cannot be read by team via ``get_item``
+    (its hash key is the uuid), so we query the ``scope-index`` GSI
+    (HASH=``scope``, RANGE=``scope_id``) exactly as budget_enforcement does:
+    ``scope == "CONFIG" AND scope_id == team``, filtered to ``scope_type ==
+    "team"``. The returned item carries ``budget_id`` (needed to write
+    ``alerts_sent`` back) and ``budget_usd`` (the admin-configured cap).
+    """
+    from boto3.dynamodb.conditions import Attr, Key  # noqa: PLC0415
+
     table = dynamodb.Table(BUDGETS_TABLE)
-    resp = table.get_item(Key={"pk": f"BUDGET#{team}", "sk": "CONFIG"})
-    return resp.get("Item")
+    resp = table.query(
+        IndexName="scope-index",
+        KeyConditionExpression=Key("scope").eq("CONFIG") & Key("scope_id").eq(team),
+        FilterExpression=Attr("scope_type").eq("team"),
+    )
+    items = resp.get("Items", [])
+    return items[0] if items else None
 
 
 def _find_top_model(metrics: list[MetricResult], team: str) -> str:
@@ -406,10 +426,14 @@ def _find_top_model(metrics: list[MetricResult], team: str) -> str:
 
 
 def _get_team_spend(team: str, period: str) -> Decimal | None:
-    """Fetch the current-period spend for a team. Returns None on failure."""
+    """Fetch the current-period spend for a team. Returns None on failure.
+
+    Reads the real ``gateway-usage`` schema (issue #261): hash=``scope_id``
+    (``team#<team>``), range=``period_date`` (``YYYY-MM``).
+    """
     usage_table = dynamodb.Table(USAGE_TABLE)
     try:
-        resp = usage_table.get_item(Key={"pk": f"USAGE#TEAM#{team}", "sk": f"PERIOD#{period}"})
+        resp = usage_table.get_item(Key={"scope_id": f"team#{team}", "period_date": period})
         item = resp.get("Item")
         return Decimal(str(item.get("total_cost_usd", "0"))) if item else Decimal(0)
     except (ClientError, Exception):
@@ -420,10 +444,12 @@ def _get_team_spend(team: str, period: str) -> Decimal | None:
 def _extract_alert_context(budget_item: dict[str, Any]) -> tuple[Decimal, list[int], list[int]] | None:
     """Extract budget amount, thresholds, and already-sent alerts from a budget record.
 
-    Returns None if the record is invalid or has no usable budget.
+    Returns None if the record is invalid or has no usable budget. budget_admin
+    stores the cap as ``budget_usd`` (issue #261); we fall back to the legacy
+    ``monthly_budget_usd`` name for any older records.
     """
     try:
-        monthly_budget = Decimal(str(budget_item.get("monthly_budget_usd", "0")))
+        monthly_budget = Decimal(str(budget_item.get("budget_usd", budget_item.get("monthly_budget_usd", "0"))))
     except (InvalidOperation, TypeError, ValueError):
         return None
     if monthly_budget <= 0:
@@ -473,17 +499,23 @@ def _process_team_alerts(
         except (ClientError, Exception):
             logger.warning("Failed to publish alert for team=%s threshold=%d", team, threshold, exc_info=True)
 
-    # Update alerts_sent in DynamoDB
+    # Update alerts_sent in DynamoDB. The budgets table is keyed by
+    # budget_id(uuid)/scope, so we must write back by the real primary key
+    # carried on the queried item (issue #261), not a phantom pk/sk.
     all_sent = sorted(set(alerts_sent + new_alerts))
-    try:
-        budgets_table = dynamodb.Table(BUDGETS_TABLE)
-        budgets_table.update_item(
-            Key={"pk": f"BUDGET#{team}", "sk": "CONFIG"},
-            UpdateExpression="SET alerts_sent = :as",
-            ExpressionAttributeValues={":as": all_sent},
-        )
-    except (ClientError, Exception):
-        logger.warning("Failed to update alerts_sent for team=%s", team, exc_info=True)
+    budget_id = budget_item.get("budget_id")
+    if budget_id:
+        try:
+            budgets_table = dynamodb.Table(BUDGETS_TABLE)
+            budgets_table.update_item(
+                Key={"budget_id": budget_id, "scope": "CONFIG"},
+                UpdateExpression="SET alerts_sent = :as",
+                ExpressionAttributeValues={":as": all_sent},
+            )
+        except (ClientError, Exception):
+            logger.warning("Failed to update alerts_sent for team=%s", team, exc_info=True)
+    else:
+        logger.warning("Budget record for team=%s missing budget_id; cannot persist alerts_sent", team)
 
     return alerts_published
 

--- a/src/cost_attribution/models.py
+++ b/src/cost_attribution/models.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel, Field, model_validator
+
+from gwcore.tiers import Tier as TenantTier
 
 
 class UsageMetrics(BaseModel):
@@ -157,15 +158,6 @@ class HandlerResponse(BaseModel):
 # ── DynamoDB record models ───────────────────────────────────────────────────
 
 
-class TenantTier(StrEnum):
-    """Supported tenant tiers for budget defaults."""
-
-    FREE = "free"
-    STANDARD = "standard"
-    PREMIUM = "premium"
-    ENTERPRISE = "enterprise"
-
-
 class ModelLimit(BaseModel):
     """Per-model spending limit within a team budget (E.5)."""
 
@@ -176,13 +168,18 @@ class ModelLimit(BaseModel):
 
 
 class BudgetRecord(BaseModel):
-    """A budget configuration stored in DynamoDB.
+    """A budget configuration stored in the ``gateway-budgets`` table.
 
-    PK: ``BUDGET#<team>``  SK: ``CONFIG``
+    Keyed by the real Terraform schema (issue #261): hash=``budget_id`` (uuid),
+    range=``scope`` (always ``"CONFIG"`` for config rows). The entity kind is in
+    ``scope_type`` and the entity id in ``scope_id``; a lookup by team goes
+    through the ``scope-index`` GSI (HASH=``scope``, RANGE=``scope_id``).
     """
 
-    pk: str = Field(description="Partition key, e.g. BUDGET#my-team")
-    sk: str = Field(default="CONFIG", description="Sort key")
+    budget_id: str = Field(description="Partition key, a uuid")
+    scope: str = Field(default="CONFIG", description="Sort key; 'CONFIG' for budget config rows")
+    scope_type: str = Field(default="team", description="Entity kind: team | user | project")
+    scope_id: str = Field(description="Entity id, e.g. the team name")
     team: str
     cost_center: str = Field(default="")
     tenant_tier: TenantTier = Field(default=TenantTier.STANDARD)
@@ -215,13 +212,16 @@ class BudgetRecord(BaseModel):
 
 
 class UsageRecord(BaseModel):
-    """Accumulated usage for a given entity+period stored in DynamoDB.
+    """Accumulated usage for a given entity+period in the ``gateway-usage`` table.
 
-    PK: ``USAGE#<entity_type>#<entity_id>``  SK: ``PERIOD#<YYYY-MM>``
+    Keyed by the real Terraform schema (issue #261): hash=``scope_id``,
+    range=``period_date``. Team monthly rows use ``scope_id = "team#<team>"``,
+    ``period_date = "YYYY-MM"``; per-model rows use
+    ``scope_id = "team#<team>#model#<model>"``.
     """
 
-    pk: str = Field(description="Partition key, e.g. USAGE#TEAM#my-team")
-    sk: str = Field(description="Sort key, e.g. PERIOD#2026-03")
+    scope_id: str = Field(description="Partition key, e.g. team#my-team")
+    period_date: str = Field(description="Sort key, e.g. 2026-03")
     total_tokens: int = Field(default=0, ge=0)
     input_tokens: int = Field(default=0, ge=0)
     output_tokens: int = Field(default=0, ge=0)

--- a/src/gwcore/__init__.py
+++ b/src/gwcore/__init__.py
@@ -20,18 +20,23 @@ from gwcore.errors import (
     ValidationFailedError,
 )
 from gwcore.responses import error_response, ok, page, parse_cursor, request_body
+from gwcore.tiers import DEFAULT_TENANT_TIER, TIER_DEFAULTS, Tier, monthly_budget_default
 
 __all__ = [
+    "DEFAULT_TENANT_TIER",
+    "TIER_DEFAULTS",
     "ConflictError",
     "ControlPlaneError",
     "ForbiddenError",
     "NotFoundError",
     "Principal",
+    "Tier",
     "UnauthorizedError",
     "ValidationFailedError",
     "authorize",
     "build_principal",
     "error_response",
+    "monthly_budget_default",
     "ok",
     "page",
     "parse_cursor",

--- a/src/gwcore/tiers.py
+++ b/src/gwcore/tiers.py
@@ -1,0 +1,49 @@
+"""Canonical tenant-tier vocabulary and quota defaults (single source of truth).
+
+The gateway is deployed by an org for its OWN internal teams — it is not a SaaS
+product — so tiers name internal quota/governance classes, not sales plans.
+Every service (team registration, budget enforcement, budget admin, cost
+attribution) imports ``Tier`` and ``TIER_DEFAULTS`` from here instead of
+redeclaring a divergent enum.
+
+Defaults are plain data (``dict``), not a service model: budget enforcement
+layers its own ``TierConfig`` Pydantic model on top, and keeping this module
+model-free avoids a cross-service import cycle. ``monthly_usd`` is an internal
+chargeback/showback figure, not revenue.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class Tier(StrEnum):
+    """Internal quota/governance tiers, ordered lowest to highest quota."""
+
+    SANDBOX = "sandbox"
+    STANDARD = "standard"
+    HIGH = "high"
+    UNLIMITED = "unlimited"
+
+
+DEFAULT_TENANT_TIER = Tier.STANDARD
+
+TIER_DEFAULTS: dict[Tier, dict[str, int]] = {
+    Tier.SANDBOX: {"rpm": 20, "tokens_per_day": 100000, "monthly_usd": 25},
+    Tier.STANDARD: {"rpm": 100, "tokens_per_day": 500000, "monthly_usd": 100},
+    Tier.HIGH: {"rpm": 500, "tokens_per_day": 5000000, "monthly_usd": 1000},
+    Tier.UNLIMITED: {"rpm": 2000, "tokens_per_day": -1, "monthly_usd": 10000},
+}
+
+
+def monthly_budget_default(tier: str | Tier) -> int:
+    """Return the default monthly USD budget for ``tier``.
+
+    Falls back to the ``STANDARD`` default for any unknown or unmapped tier, so
+    callers never need to special-case a missing key.
+    """
+    try:
+        key = Tier(tier)
+    except ValueError:
+        key = Tier.STANDARD
+    return TIER_DEFAULTS[key]["monthly_usd"]

--- a/src/rate_limiter/handler.py
+++ b/src/rate_limiter/handler.py
@@ -44,9 +44,13 @@ def _get_table():
 def _increment_rpm_counter(team: str) -> int:
     """Atomically increment the RPM counter for the current minute bucket.
 
-    Key schema:
-        PK = RATE#RPM#{team}
-        SK = MINUTE#{epoch_minute}
+    Key schema (real ``gateway-usage`` table, issue #261 — hash=``scope_id``,
+    range=``period_date``, see infrastructure/modules/budgets/main.tf):
+        scope_id    = ratelimit#rpm#{team}
+        period_date = minute#{epoch_minute}
+
+    The distinct ``ratelimit#`` scope_id prefix keeps these counters from
+    colliding with the monthly spend rows (``team#…`` / ``user#…``).
 
     TTL: expires_at = start-of-current-minute epoch + 120 seconds (two full
     minutes), giving DynamoDB time to clean up after the window closes.
@@ -61,8 +65,8 @@ def _increment_rpm_counter(team: str) -> int:
     table = _get_table()
     resp = table.update_item(
         Key={
-            "pk": f"RATE#RPM#{team}",
-            "sk": f"MINUTE#{minute_bucket}",
+            "scope_id": f"ratelimit#rpm#{team}",
+            "period_date": f"minute#{minute_bucket}",
         },
         UpdateExpression="SET #cnt = if_not_exists(#cnt, :zero) + :inc, #ttl = :ttl",
         ExpressionAttributeNames={
@@ -82,9 +86,10 @@ def _increment_rpm_counter(team: str) -> int:
 def _increment_daily_token_counter(team: str, tokens: int) -> int:
     """Atomically add tokens to the daily counter for a team.
 
-    Key schema:
-        PK = RATE#TOKENS#{team}
-        SK = DAY#{YYYY-MM-DD}
+    Key schema (real ``gateway-usage`` table, issue #261 — hash=``scope_id``,
+    range=``period_date``):
+        scope_id    = ratelimit#tokens#{team}
+        period_date = day#{YYYY-MM-DD}
 
     TTL: expires_at = end-of-day epoch + 3600 seconds (one hour grace).
 
@@ -100,8 +105,8 @@ def _increment_daily_token_counter(team: str, tokens: int) -> int:
     table = _get_table()
     resp = table.update_item(
         Key={
-            "pk": f"RATE#TOKENS#{team}",
-            "sk": f"DAY#{day_str}",
+            "scope_id": f"ratelimit#tokens#{team}",
+            "period_date": f"day#{day_str}",
         },
         UpdateExpression="SET #cnt = if_not_exists(#cnt, :zero) + :inc, #ttl = :ttl",
         ExpressionAttributeNames={
@@ -141,13 +146,13 @@ def check_rate_limit(
     """Check RPM and daily token limits for a team.
 
     RPM check: DynamoDB sliding window counter
-    - Key: PK=RATE#RPM#{team}, SK=MINUTE#{minute_bucket}
+    - Key: scope_id=ratelimit#rpm#{team}, period_date=minute#{minute_bucket}
     - Atomic ADD 1 on each call
     - TTL: expires_at = current minute epoch + 120 seconds
     - Compare count against rpm_limit
 
     Daily token check:
-    - Key: PK=RATE#TOKENS#{team}, SK=DAY#{YYYY-MM-DD}
+    - Key: scope_id=ratelimit#tokens#{team}, period_date=day#{YYYY-MM-DD}
     - Atomic ADD estimated_tokens on each call
     - TTL: expires_at = end of day + 3600 seconds
     - Compare against tokens_per_day_limit (-1 = unlimited)

--- a/src/team_registration/models.py
+++ b/src/team_registration/models.py
@@ -6,14 +6,7 @@ from enum import StrEnum
 
 from pydantic import BaseModel, EmailStr, Field
 
-
-class Tier(StrEnum):
-    """Supported billing tiers."""
-
-    FREE = "free"
-    STANDARD = "standard"
-    PREMIUM = "premium"
-    ENTERPRISE = "enterprise"
+from gwcore.tiers import TIER_DEFAULTS, Tier
 
 
 class TeamStatus(StrEnum):
@@ -24,13 +17,10 @@ class TeamStatus(StrEnum):
 
 
 # ── Tier budget defaults (monthly USD) ───────────────────────────────────────
+# Backwards-compatible alias derived from the canonical gwcore table, keyed by
+# tier string value so ``TIER_BUDGET_DEFAULTS.get(tier_str)`` lookups still work.
 
-TIER_BUDGET_DEFAULTS: dict[str, int] = {
-    Tier.FREE: 10,
-    Tier.STANDARD: 1000,
-    Tier.PREMIUM: 10000,
-    Tier.ENTERPRISE: 100000,
-}
+TIER_BUDGET_DEFAULTS: dict[str, int] = {t.value: d["monthly_usd"] for t, d in TIER_DEFAULTS.items()}
 
 
 # ── Request models ───────────────────────────────────────────────────────────

--- a/src/team_registration/routes.py
+++ b/src/team_registration/routes.py
@@ -145,18 +145,28 @@ def register_team(event: dict[str, Any], principal: auth.Principal) -> dict[str,
         }
     )
 
+    # Seed the onboarding budget on the real ``gateway-budgets`` schema
+    # (issue #261): keyed by budget_id(uuid)/scope, entity id in scope_id,
+    # entity kind in scope_type. Conforms to budget_admin.create_budget so the
+    # seeded budget is visible to enforcement (via the scope-index GSI) and to
+    # budget_admin. Uses ``budget_usd`` (the field enforcement's adapter reads),
+    # NOT ``monthly_budget_usd``.
     budget = TIER_BUDGET_DEFAULTS.get(request.tier.value, 1000)
+    budget_id = str(uuid.uuid4())
     dynamodb.Table(BUDGETS_TABLE).put_item(
         Item={
-            "pk": f"BUDGET#{request.team_name}",
-            "sk": "CONFIG",
+            "budget_id": budget_id,
+            "scope": "CONFIG",
+            "scope_type": "team",
+            "scope_id": request.team_name,
+            "budget_usd": Decimal(str(budget)),
+            "period": "monthly",
+            "tier": request.tier.value,
+            "alert_thresholds": [50, 80, 100],
             "team_id": team_id,
             "team_name": request.team_name,
-            "monthly_budget_usd": Decimal(str(budget)),
-            "warn_threshold_pct": 80,
-            "hard_limit_pct": 100,
-            "tier": request.tier.value,
             "created_at": now,
+            "updated_at": now,
         }
     )
 
@@ -244,23 +254,35 @@ def get_team(team_id: str) -> dict[str, Any]:
 
 
 def _get_usage_summary(team_name: str, tier: str) -> UsageSummary:
-    """Build a usage summary from the budgets and usage tables."""
+    """Build a usage summary from the budgets and usage tables.
+
+    Reads the real Terraform schemas (issue #261): the team budget is looked up
+    on the ``gateway-budgets`` ``scope-index`` GSI (``scope`` == "CONFIG",
+    ``scope_id`` == team, ``scope_type`` == "team") since the base table is
+    keyed by budget_id(uuid); usage is read from ``gateway-usage`` by
+    ``scope_id`` (``team#<team>``) / ``period_date`` (``YYYY-MM``).
+    """
+    from boto3.dynamodb.conditions import Attr, Key  # noqa: PLC0415
+
     period = _current_period()
     budget = float(TIER_BUDGET_DEFAULTS.get(tier, 1000))
 
     try:
-        budget_resp = dynamodb.Table(BUDGETS_TABLE).get_item(Key={"pk": f"BUDGET#{team_name}", "sk": "CONFIG"})
-        budget_item = budget_resp.get("Item")
-        if budget_item:
-            budget = float(Decimal(str(budget_item.get("monthly_budget_usd", budget))))
+        budget_resp = dynamodb.Table(BUDGETS_TABLE).query(
+            IndexName="scope-index",
+            KeyConditionExpression=Key("scope").eq("CONFIG") & Key("scope_id").eq(team_name),
+            FilterExpression=Attr("scope_type").eq("team"),
+        )
+        budget_items = budget_resp.get("Items", [])
+        if budget_items:
+            budget_item = budget_items[0]
+            budget = float(Decimal(str(budget_item.get("budget_usd", budget_item.get("monthly_budget_usd", budget)))))
     except (ClientError, InvalidOperation):
         logger.debug("Could not fetch budget for team=%s, using tier default", team_name)
 
     total_cost = 0.0
     try:
-        usage_resp = dynamodb.Table(USAGE_TABLE).get_item(
-            Key={"pk": f"USAGE#TEAM#{team_name}", "sk": f"PERIOD#{period}"}
-        )
+        usage_resp = dynamodb.Table(USAGE_TABLE).get_item(Key={"scope_id": f"team#{team_name}", "period_date": period})
         usage_item = usage_resp.get("Item")
         if usage_item:
             total_cost = float(Decimal(str(usage_item.get("total_cost_usd", "0"))))

--- a/src/usage_api/handler.py
+++ b/src/usage_api/handler.py
@@ -37,35 +37,52 @@ dynamodb = boto3.resource("dynamodb", region_name=os.environ.get("AWS_REGION", "
 
 
 def _get_team_usage(team: str, period: str) -> dict[str, Any] | None:
-    """Fetch usage for a team in a single period from DynamoDB."""
+    """Fetch usage for a team in a single period from DynamoDB.
+
+    Reads the real ``gateway-usage`` schema (issue #261): hash=``scope_id``
+    (``team#<team>``), range=``period_date`` (``YYYY-MM``).
+    """
     table = dynamodb.Table(USAGE_TABLE)
-    resp = table.get_item(Key={"pk": f"USAGE#TEAM#{team}", "sk": f"PERIOD#{period}"})
+    resp = table.get_item(Key={"scope_id": f"team#{team}", "period_date": period})
     return resp.get("Item")
 
 
 def _get_budget_config(team: str) -> dict[str, Any] | None:
-    """Fetch the budget configuration for a team from DynamoDB."""
+    """Fetch the team-scoped budget configuration from DynamoDB (issue #261).
+
+    The physical ``gateway-budgets`` table is keyed by ``budget_id`` (uuid) +
+    ``scope``, so a lookup by team goes through the ``scope-index`` GSI
+    (HASH=``scope`` == "CONFIG", RANGE=``scope_id`` == team), filtered to
+    ``scope_type == "team"`` — the same path budget_enforcement uses.
+    """
+    from boto3.dynamodb.conditions import Attr  # noqa: PLC0415
+
     table = dynamodb.Table(BUDGETS_TABLE)
-    resp = table.get_item(Key={"pk": f"BUDGET#{team}", "sk": "CONFIG"})
-    return resp.get("Item")
+    resp = table.query(
+        IndexName="scope-index",
+        KeyConditionExpression=Key("scope").eq("CONFIG") & Key("scope_id").eq(team),
+        FilterExpression=Attr("scope_type").eq("team"),
+    )
+    items = resp.get("Items", [])
+    return items[0] if items else None
 
 
 def _get_model_usage_for_team(team: str, period: str) -> list[dict[str, Any]]:
     """Scan for all model-level usage rows for a team in a given period.
 
-    DDB pattern: PK begins_with ``USAGE#TEAM#{team}#MODEL#``, SK = ``PERIOD#{period}``
+    DDB pattern (real ``gateway-usage`` schema, issue #261): ``scope_id``
+    begins_with ``team#{team}#model#``, ``period_date`` == ``{period}``.
     """
     table = dynamodb.Table(USAGE_TABLE)
     items: list[dict[str, Any]] = []
 
-    response = table.scan(
-        FilterExpression=Key("pk").begins_with(f"USAGE#TEAM#{team}#MODEL#") & Key("sk").eq(f"PERIOD#{period}"),
-    )
+    filter_expr = Key("scope_id").begins_with(f"team#{team}#model#") & Key("period_date").eq(period)
+    response = table.scan(FilterExpression=filter_expr)
     items.extend(response.get("Items", []))
 
     while "LastEvaluatedKey" in response:
         response = table.scan(
-            FilterExpression=Key("pk").begins_with(f"USAGE#TEAM#{team}#MODEL#") & Key("sk").eq(f"PERIOD#{period}"),
+            FilterExpression=filter_expr,
             ExclusiveStartKey=response["LastEvaluatedKey"],
         )
         items.extend(response.get("Items", []))
@@ -114,14 +131,15 @@ def _item_to_usage_period(item: dict[str, Any], period: str) -> UsagePeriod:
 def _item_to_model_usage(item: dict[str, Any]) -> ModelUsage | None:
     """Convert a DynamoDB model-level usage item to a ``ModelUsage`` model.
 
-    Extracts the model name from the PK: ``USAGE#TEAM#{team}#MODEL#{model}``.
+    Extracts the model name from the scope_id: ``team#{team}#model#{model}``
+    (issue #261, real ``gateway-usage`` schema).
     """
-    pk = item.get("pk", "")
-    marker = "#MODEL#"
-    idx = pk.find(marker)
+    scope_id = item.get("scope_id", "")
+    marker = "#model#"
+    idx = scope_id.find(marker)
     if idx == -1:
         return None
-    model_name = pk[idx + len(marker) :]
+    model_name = scope_id[idx + len(marker) :]
     if not model_name:
         return None
 
@@ -162,7 +180,11 @@ def _handle_usage(team: str, history: int, models: bool) -> dict[str, Any]:
     try:
         budget_item = _get_budget_config(team)
         if budget_item:
-            monthly_budget_usd = _safe_decimal(budget_item.get("monthly_budget_usd", "0"))
+            # budget_admin writes the cap as ``budget_usd`` (issue #261); fall
+            # back to the legacy ``monthly_budget_usd`` name for older records.
+            monthly_budget_usd = _safe_decimal(
+                budget_item.get("budget_usd", budget_item.get("monthly_budget_usd", "0"))
+            )
             if monthly_budget_usd > 0 and current_period:
                 budget_utilization_pct = round(float(current_period.total_cost_usd / monthly_budget_usd * 100), 1)
     except ClientError:

--- a/tests/test_budget_admin.py
+++ b/tests/test_budget_admin.py
@@ -232,7 +232,7 @@ class TestGetBudget:
                 "scope_id": "platform",
                 "budget_usd": Decimal(5000),
                 "period": "monthly",
-                "tier": "premium",
+                "tier": "high",
                 "alert_thresholds": [50, 80, 100],
                 "created_at": "2026-01-01T00:00:00",
                 "updated_at": "2026-03-01T00:00:00",
@@ -294,7 +294,7 @@ class TestCreateBudget:
             "scope_id": "platform-eng",
             "budget_usd": "5000.00",
             "period": "monthly",
-            "tier": "premium",
+            "tier": "high",
             "alert_thresholds": [50, 80, 100],
         }
         result = handler(_make_event(method="POST", path="/budgets", body=body))
@@ -363,7 +363,7 @@ class TestUpdateBudget:
     @patch("budget_admin.routes._budgets_table")
     def test_update_multiple_fields(self, mock_table: Any, _audit: Any) -> None:
         mock_table.return_value.update_item.return_value = {"Attributes": {}}
-        body = {"budget_usd": "3000", "tier": "enterprise", "alert_thresholds": [60, 90, 100]}
+        body = {"budget_usd": "3000", "tier": "unlimited", "alert_thresholds": [60, 90, 100]}
         result = handler(_make_event(method="PUT", path="/budgets/abc-123", body=body))
         assert result["statusCode"] == 200
 
@@ -772,7 +772,7 @@ class TestModels:
             budget_usd=Decimal(50000),
             token_limit=1_000_000,
             period="quarterly",
-            tier="enterprise",
+            tier="unlimited",
             model_limits=[{"model": "claude-sonnet-4-20250514", "max_cost_usd": Decimal(10000)}],
             alert_thresholds=[25, 50, 75, 100],
         )

--- a/tests/test_budget_enforcement.py
+++ b/tests/test_budget_enforcement.py
@@ -188,7 +188,7 @@ class TestTierConfig:
         assert tc.tokens_per_day == -1
 
     def test_default_tier_defaults_loaded(self) -> None:
-        """Built-in defaults should include sandbox, standard, premium, unlimited."""
+        """Built-in defaults should include sandbox, standard, high, unlimited."""
         assert "sandbox" in TIER_DEFAULTS or "standard" in TIER_DEFAULTS
         for tier_cfg in TIER_DEFAULTS.values():
             assert isinstance(tier_cfg, TierConfig)
@@ -216,20 +216,14 @@ class TestTierConfig:
             result = _load_tier_defaults()
         assert len(result) > 0
 
-    def test_load_tier_defaults_legacy_env_vars(self) -> None:
-        """Legacy per-tier env vars should be used when TIER_DEFAULTS is absent."""
-        env = {
-            "TIER_DEFAULT_FREE": "5",
-            "TIER_DEFAULT_STANDARD": "500",
-            "TIER_DEFAULT_PREMIUM": "5000",
-            "TIER_DEFAULT_ENTERPRISE": "50000",
-        }
-        with patch.dict(os.environ, env, clear=False):
-            # Remove TIER_DEFAULTS if present
+    def test_load_tier_defaults_builtin_when_env_absent(self) -> None:
+        """With no TIER_DEFAULTS env var, the built-in gwcore defaults are used."""
+        with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("TIER_DEFAULTS", None)
             result = _load_tier_defaults()
-        assert result["free"].monthly_usd == Decimal(5)
-        assert result["standard"].monthly_usd == Decimal(500)
+        assert result["standard"].monthly_usd == Decimal(100)
+        assert result["high"].monthly_usd == Decimal(1000)
+        assert set(result) == {"sandbox", "standard", "high", "unlimited"}
 
     def test_tier_default_fallback_for_unknown_tier(self) -> None:
         """Unknown tier should fall back to standard."""

--- a/tests/test_budget_roundtrip.py
+++ b/tests/test_budget_roundtrip.py
@@ -1,0 +1,328 @@
+"""Round-trip regression test for issue #261.
+
+Admin-created budgets were invisible to enforcement because the two services
+used different DynamoDB key schemas against the same ``gateway-budgets`` table:
+budget_admin writes ``budget_id``/``scope``/``scope_id``/``scope_type`` (matching
+the physical table + ``scope-index`` GSI), while enforcement read a nonexistent
+``pk``/``sk`` key, which raises ValidationException against real DynamoDB and
+silently failed open (``budget-check-degraded``).
+
+This test stands up a REAL moto-backed DynamoDB table with the ACTUAL key
+schema from ``infrastructure/modules/budgets/main.tf`` (hash=budget_id,
+range=scope, plus the ``scope-index`` GSI HASH=scope RANGE=scope_id), writes a
+budget through the budget_admin ``create_budget`` path, then asserts enforcement
+can see and enforce it. Using the real key schema is the crux: it is what makes
+the pre-fix ``get_item(Key={"pk": ..., "sk": ...})`` blow up.
+
+``TestBudgetRoundTrip`` mocks the usage-table reads to stay scoped to the
+budgets-table key mismatch. ``TestBudgetUsageEndToEnd`` closes the loop: it
+stands up BOTH physical tables (budgets + usage) at their real schemas, writes
+usage through cost_attribution's real ``_accumulate_usage`` path, and reads it
+back through enforcement's real ``_get_current_usage`` with NO usage mock —
+proving the writer and reader agree on the ``gateway-usage`` schema too.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from decimal import Decimal
+from typing import Any
+from unittest.mock import patch
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from budget_admin import routes as admin_routes
+from budget_enforcement import handler as enforcement
+from budget_enforcement.models import BudgetCheckRequest
+from cost_attribution import handler as cost_attribution
+from cost_attribution.models import MetricResult
+from gwcore import auth
+from rate_limiter import handler as rate_limiter
+
+TABLE_NAME = "gateway-budgets"
+USAGE_TABLE_NAME = "gateway-usage"
+REGION = "us-east-1"
+
+
+def _make_jwt(claims: dict[str, Any]) -> str:
+    """Build a fake (unverified) JWT with the given payload claims."""
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).decode().rstrip("=")
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    signature = base64.urlsafe_b64encode(b"fakesig").decode().rstrip("=")
+    return f"{header}.{payload}.{signature}"
+
+
+def _create_budgets_table(dynamodb: Any) -> Any:
+    """Create the ``gateway-budgets`` table with the real Terraform key schema."""
+    return dynamodb.create_table(
+        TableName=TABLE_NAME,
+        BillingMode="PAY_PER_REQUEST",
+        KeySchema=[
+            {"AttributeName": "budget_id", "KeyType": "HASH"},
+            {"AttributeName": "scope", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "budget_id", "AttributeType": "S"},
+            {"AttributeName": "scope", "AttributeType": "S"},
+            {"AttributeName": "scope_id", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "scope-index",
+                "KeySchema": [
+                    {"AttributeName": "scope", "KeyType": "HASH"},
+                    {"AttributeName": "scope_id", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+    )
+
+
+def _create_usage_table(dynamodb: Any) -> Any:
+    """Create the ``gateway-usage`` table with the real Terraform key schema.
+
+    hash=``scope_id``, range=``period_date``, plus the ``period-index`` GSI
+    (HASH=``period_date``) and a TTL attribute ``expires_at`` — matching
+    infrastructure/modules/budgets/main.tf.
+    """
+    return dynamodb.create_table(
+        TableName=USAGE_TABLE_NAME,
+        BillingMode="PAY_PER_REQUEST",
+        KeySchema=[
+            {"AttributeName": "scope_id", "KeyType": "HASH"},
+            {"AttributeName": "period_date", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "scope_id", "AttributeType": "S"},
+            {"AttributeName": "period_date", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "period-index",
+                "KeySchema": [{"AttributeName": "period_date", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+    )
+
+
+def _create_budget_via_admin(team: str, budget_usd: str) -> str:
+    """Exercise the budget_admin write path and return the new budget_id."""
+    principal = auth.Principal(sub="admin-user", scopes=frozenset({auth.INVOKE_SCOPE}), team="admin-team")
+    body = {
+        "scope": "team",
+        "scope_id": team,
+        "budget_usd": budget_usd,
+        "period": "monthly",
+        "tier": "standard",
+        "alert_thresholds": [50, 80, 100],
+        "model_limits": [{"model": "claude-opus-4", "max_cost_usd": "200"}],
+    }
+    event = {
+        "requestContext": {"requestId": "rid-test", "http": {"method": "POST", "path": "/budgets"}},
+        "body": json.dumps(body),
+        "isBase64Encoded": False,
+    }
+    with patch("budget_admin.routes.audit.emit"):
+        result = admin_routes.create_budget(event, principal)
+    return result["body"] if isinstance(result["body"], str) else json.loads(result["body"])["budget_id"]
+
+
+@pytest.fixture
+def moto_budgets_table(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Stand up a real moto DynamoDB budgets table wired into both services."""
+    with mock_aws():
+        dynamodb = boto3.resource("dynamodb", region_name=REGION)
+        _create_budgets_table(dynamodb)
+
+        # Point budget_admin's write path at the moto table.
+        admin_routes.init_dynamodb(TABLE_NAME, "gateway-usage", region=REGION)
+        # Point budget_enforcement's read path at the moto-backed resource + table.
+        monkeypatch.setattr(enforcement, "dynamodb", boto3.resource("dynamodb", region_name=REGION))
+        monkeypatch.setattr(enforcement, "BUDGETS_TABLE", TABLE_NAME)
+        yield dynamodb
+
+
+@pytest.fixture
+def moto_both_tables(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Stand up BOTH real-schema moto tables wired into every service.
+
+    This is the full end-to-end path (issue #261): usage is written by
+    cost_attribution's real ``_accumulate_usage`` and read by budget_enforcement
+    with NO usage mock, proving admin budgets and accumulated usage line up on
+    the physical schemas.
+    """
+    with mock_aws():
+        dynamodb = boto3.resource("dynamodb", region_name=REGION)
+        _create_budgets_table(dynamodb)
+        _create_usage_table(dynamodb)
+
+        resource = boto3.resource("dynamodb", region_name=REGION)
+
+        # budget_admin write path -> moto tables.
+        admin_routes.init_dynamodb(TABLE_NAME, USAGE_TABLE_NAME, region=REGION)
+        # Point every service's module-level resource + table names at moto.
+        for module in (enforcement, cost_attribution, rate_limiter):
+            monkeypatch.setattr(module, "dynamodb", resource, raising=False)
+        monkeypatch.setattr(enforcement, "BUDGETS_TABLE", TABLE_NAME)
+        monkeypatch.setattr(enforcement, "USAGE_TABLE", USAGE_TABLE_NAME)
+        monkeypatch.setattr(cost_attribution, "BUDGETS_TABLE", TABLE_NAME)
+        monkeypatch.setattr(cost_attribution, "USAGE_TABLE", USAGE_TABLE_NAME)
+        monkeypatch.setattr(rate_limiter, "USAGE_TABLE", USAGE_TABLE_NAME)
+        yield dynamodb
+
+
+def _accumulate_team_spend(team: str, cost_usd: float) -> None:
+    """Write team usage through cost_attribution's REAL accumulation path."""
+    metric = MetricResult(
+        provider="anthropic",
+        model="claude-opus-4",
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        cost_usd=cost_usd,
+        team=team,
+        user="user1",
+    )
+    cost_attribution._accumulate_usage([metric])
+
+
+class TestBudgetUsageEndToEnd:
+    """Full round-trip over BOTH physical tables with NO usage mock (issue #261).
+
+    Usage is written via cost_attribution's real ``_accumulate_usage`` and read
+    back by budget_enforcement's real ``_get_current_usage`` — the proof that
+    the writer and reader agree on the physical ``gateway-usage`` schema.
+    """
+
+    def test_denies_when_accumulated_usage_over_admin_budget(self, moto_both_tables: Any) -> None:
+        # Admin sets a low $100 budget; real usage of $150 is written.
+        _create_budget_via_admin(team="platform", budget_usd="100")
+        _accumulate_team_spend("platform", 150.0)
+
+        # Sanity: enforcement reads the accumulated spend WITHOUT any mock.
+        assert enforcement._get_current_usage("platform") == Decimal(150)
+
+        jwt = _make_jwt({"custom:team": "platform", "sub": "user1"})
+        result = enforcement._check_budget(BudgetCheckRequest(jwt_token=jwt))
+
+        assert result.allowed is False
+        assert result.status_code == 429
+        assert "exceeded" in result.reason.lower()
+        assert result.budget_status is not None
+        assert result.budget_status.monthly_budget_usd == Decimal(100)
+        assert result.budget_status.current_spend_usd == Decimal(150)
+
+    def test_allows_when_accumulated_usage_under_admin_budget(self, moto_both_tables: Any) -> None:
+        _create_budget_via_admin(team="platform", budget_usd="5000")
+        _accumulate_team_spend("platform", 100.0)
+
+        assert enforcement._get_current_usage("platform") == Decimal(100)
+
+        jwt = _make_jwt({"custom:team": "platform", "sub": "user1"})
+        result = enforcement._check_budget(BudgetCheckRequest(jwt_token=jwt))
+
+        assert result.allowed is True
+        assert result.budget_status is not None
+        assert result.budget_status.monthly_budget_usd == Decimal(5000)
+        assert result.budget_status.current_spend_usd == Decimal(100)
+
+    def test_no_usage_written_reads_zero_and_allows(self, moto_both_tables: Any) -> None:
+        # A budget exists but no usage has been accumulated: real read is 0.
+        _create_budget_via_admin(team="platform", budget_usd="5000")
+
+        assert enforcement._get_current_usage("platform") == Decimal("0.00")
+
+        jwt = _make_jwt({"custom:team": "platform", "sub": "user1"})
+        result = enforcement._check_budget(BudgetCheckRequest(jwt_token=jwt))
+
+        assert result.allowed is True
+
+
+class TestBudgetRoundTrip:
+    def test_admin_budget_visible_to_enforcement(self, moto_budgets_table: Any) -> None:
+        """A budget created via budget_admin is found by enforcement's lookup."""
+        _create_budget_via_admin(team="platform", budget_usd="5000")
+
+        record = enforcement._get_budget_record("platform")
+
+        assert record is not None, "enforcement could not see the admin-created budget"
+        assert record["scope_type"] == "team"
+        assert record["scope_id"] == "platform"
+        # Field-vocabulary translation applied.
+        assert Decimal(str(record["monthly_budget_usd"])) == Decimal(5000)
+        assert record["warn_threshold_pct"] == 80.0  # highest alert threshold < 100
+        assert record["hard_limit_pct"] == 100
+
+    def test_no_budget_for_unknown_team_returns_none(self, moto_budgets_table: Any) -> None:
+        """A team with no configured budget returns None (falls back to tiers)."""
+        _create_budget_via_admin(team="platform", budget_usd="5000")
+        assert enforcement._get_budget_record("no-such-team") is None
+
+    def test_user_scoped_budget_not_matched_as_team(self, moto_budgets_table: Any) -> None:
+        """A user-scoped budget sharing the id is not returned for the team lookup."""
+        principal = auth.Principal(sub="admin", scopes=frozenset({auth.INVOKE_SCOPE}), team="admin")
+        body = {"scope": "user", "scope_id": "platform", "budget_usd": "10"}
+        event = {
+            "requestContext": {"requestId": "r", "http": {"method": "POST", "path": "/budgets"}},
+            "body": json.dumps(body),
+            "isBase64Encoded": False,
+        }
+        with patch("budget_admin.routes.audit.emit"):
+            admin_routes.create_budget(event, principal)
+
+        assert enforcement._get_budget_record("platform") is None
+
+    def test_enforcement_blocks_when_usage_over_admin_budget(self, moto_budgets_table: Any) -> None:
+        """Full round-trip: admin sets a low budget, usage above it -> deny (429)."""
+        _create_budget_via_admin(team="platform", budget_usd="100")
+
+        jwt = _make_jwt({"custom:team": "platform", "sub": "user1"})
+        req = BudgetCheckRequest(jwt_token=jwt)
+
+        # Mock only the usage-table reads (separate, out-of-scope key mismatch).
+        with patch.object(enforcement, "_get_current_usage", return_value=Decimal("150.00")):
+            result = enforcement._check_budget(req)
+
+        assert result.allowed is False
+        assert result.status_code == 429
+        assert "exceeded" in result.reason.lower()
+        assert result.budget_status is not None
+        assert result.budget_status.monthly_budget_usd == Decimal(100)
+
+    def test_enforcement_allows_when_usage_under_admin_budget(self, moto_budgets_table: Any) -> None:
+        """Full round-trip: usage below the admin budget -> allow."""
+        _create_budget_via_admin(team="platform", budget_usd="5000")
+
+        jwt = _make_jwt({"custom:team": "platform", "sub": "user1"})
+        req = BudgetCheckRequest(jwt_token=jwt)
+
+        with patch.object(enforcement, "_get_current_usage", return_value=Decimal("100.00")):
+            result = enforcement._check_budget(req)
+
+        assert result.allowed is True
+        assert result.budget_status is not None
+        assert result.budget_status.monthly_budget_usd == Decimal(5000)
+
+    def test_admin_model_limit_enforced(self, moto_budgets_table: Any) -> None:
+        """The admin list-form model_limits round-trips into a per-model cap."""
+        _create_budget_via_admin(team="platform", budget_usd="5000")
+
+        jwt = _make_jwt({"custom:team": "platform", "sub": "user1"})
+        req = BudgetCheckRequest(jwt_token=jwt, model="claude-opus-4")
+
+        with (
+            patch.object(enforcement, "_get_current_usage", return_value=Decimal("100.00")),
+            patch.object(enforcement, "_get_model_usage", return_value=Decimal("250.00")),
+        ):
+            result = enforcement._check_budget(req)
+
+        assert result.allowed is False
+        assert result.status_code == 429
+        assert result.error is not None
+        assert result.error.model == "claude-opus-4"
+        assert result.error.limit_usd == Decimal(200)

--- a/tests/test_chargeback_report.py
+++ b/tests/test_chargeback_report.py
@@ -36,8 +36,8 @@ from chargeback_report.report_template import (
 
 
 TEAM_ALPHA_USAGE = {
-    "pk": "USAGE#TEAM#alpha",
-    "sk": "PERIOD#2026-03",
+    "scope_id": "team#alpha",
+    "period_date": "2026-03",
     "total_tokens": 500000,
     "input_tokens": 300000,
     "output_tokens": 200000,
@@ -49,8 +49,8 @@ TEAM_ALPHA_USAGE = {
 }
 
 TEAM_BETA_USAGE = {
-    "pk": "USAGE#TEAM#beta",
-    "sk": "PERIOD#2026-03",
+    "scope_id": "team#beta",
+    "period_date": "2026-03",
     "total_tokens": 1200000,
     "input_tokens": 800000,
     "output_tokens": 400000,
@@ -62,8 +62,8 @@ TEAM_BETA_USAGE = {
 }
 
 TEAM_GAMMA_USAGE = {
-    "pk": "USAGE#TEAM#gamma",
-    "sk": "PERIOD#2026-03",
+    "scope_id": "team#gamma",
+    "period_date": "2026-03",
     "total_tokens": 50000,
     "input_tokens": 30000,
     "output_tokens": 20000,
@@ -235,8 +235,8 @@ class TestBuildTeamSummaries:
         summaries = _build_team_summaries([], BUDGET_LIMITS)
         assert summaries == []
 
-    def test_malformed_pk_skipped(self) -> None:
-        items = [{"pk": "USAGE#TEAM#", "sk": "PERIOD#2026-03", "total_cost_usd": Decimal(10)}]
+    def test_malformed_scope_id_skipped(self) -> None:
+        items = [{"scope_id": "team#", "period_date": "2026-03", "total_cost_usd": Decimal(10)}]
         summaries = _build_team_summaries(items, {})
         assert len(summaries) == 0
 
@@ -382,9 +382,9 @@ class TestHandler:
             {"Items": ALL_USAGE_ITEMS},  # usage query for current month
             {
                 "Items": [  # budgets query
-                    {"scope": "team", "scope_id": "alpha", "monthly_budget_usd": Decimal(200)},
-                    {"scope": "team", "scope_id": "beta", "monthly_budget_usd": Decimal(500)},
-                    {"scope": "team", "scope_id": "gamma", "monthly_budget_usd": Decimal(50)},
+                    {"scope": "CONFIG", "scope_type": "team", "scope_id": "alpha", "budget_usd": Decimal(200)},
+                    {"scope": "CONFIG", "scope_type": "team", "scope_id": "beta", "budget_usd": Decimal(500)},
+                    {"scope": "CONFIG", "scope_type": "team", "scope_id": "gamma", "budget_usd": Decimal(50)},
                 ]
             },
             {"Items": ALL_USAGE_ITEMS},  # usage query for previous month

--- a/tests/test_cost_attribution.py
+++ b/tests/test_cost_attribution.py
@@ -628,12 +628,20 @@ class TestCheckAndPublishAlerts:
 
         mock_ddb.Table.side_effect = table_router
 
-        mock_budgets_table.get_item.return_value = {
-            "Item": {
-                "monthly_budget_usd": Decimal(1000),
-                "alert_thresholds": [50, 80, 100],
-                "alerts_sent": [],
-            }
+        # Budget lookup goes through the scope-index GSI query (issue #261);
+        # the item carries budget_usd + budget_id (needed for write-back).
+        mock_budgets_table.query.return_value = {
+            "Items": [
+                {
+                    "budget_id": "b-1",
+                    "scope": "CONFIG",
+                    "scope_type": "team",
+                    "scope_id": "team-a",
+                    "budget_usd": Decimal(1000),
+                    "alert_thresholds": [50, 80, 100],
+                    "alerts_sent": [],
+                }
+            ]
         }
         mock_usage_table.get_item.return_value = {
             "Item": {"total_cost_usd": Decimal(550)}  # 55% -> crosses 50
@@ -662,12 +670,18 @@ class TestCheckAndPublishAlerts:
 
         mock_ddb.Table.side_effect = table_router
 
-        mock_budgets_table.get_item.return_value = {
-            "Item": {
-                "monthly_budget_usd": Decimal(1000),
-                "alert_thresholds": [50, 80, 100],
-                "alerts_sent": [50],  # Already sent
-            }
+        mock_budgets_table.query.return_value = {
+            "Items": [
+                {
+                    "budget_id": "b-1",
+                    "scope": "CONFIG",
+                    "scope_type": "team",
+                    "scope_id": "team-a",
+                    "budget_usd": Decimal(1000),
+                    "alert_thresholds": [50, 80, 100],
+                    "alerts_sent": [50],  # Already sent
+                }
+            ]
         }
         mock_usage_table.get_item.return_value = {
             "Item": {"total_cost_usd": Decimal(550)}  # 55%
@@ -693,12 +707,18 @@ class TestCheckAndPublishAlerts:
 
         mock_ddb.Table.side_effect = table_router
 
-        mock_budgets_table.get_item.return_value = {
-            "Item": {
-                "monthly_budget_usd": Decimal(1000),
-                "alert_thresholds": [50, 80, 100],
-                "alerts_sent": [],
-            }
+        mock_budgets_table.query.return_value = {
+            "Items": [
+                {
+                    "budget_id": "b-1",
+                    "scope": "CONFIG",
+                    "scope_type": "team",
+                    "scope_id": "team-a",
+                    "budget_usd": Decimal(1000),
+                    "alert_thresholds": [50, 80, 100],
+                    "alerts_sent": [],
+                }
+            ]
         }
         mock_usage_table.get_item.return_value = {
             "Item": {"total_cost_usd": Decimal(850)}  # 85% -> crosses 50 and 80
@@ -724,7 +744,7 @@ class TestCheckAndPublishAlerts:
 
         mock_ddb.Table.side_effect = table_router
 
-        mock_budgets_table.get_item.return_value = {}  # No Item
+        mock_budgets_table.query.return_value = {"Items": []}  # No budget row
 
         result = check_and_publish_alerts([_metric(cost_usd=10.0)])
 
@@ -746,20 +766,28 @@ class TestCheckAndPublishAlerts:
 
         mock_ddb.Table.side_effect = table_router
 
-        mock_budgets_table.get_item.return_value = {
-            "Item": {
-                "monthly_budget_usd": Decimal(1000),
-                "alert_thresholds": [50, 80, 100],
-                "alerts_sent": [],
-            }
+        mock_budgets_table.query.return_value = {
+            "Items": [
+                {
+                    "budget_id": "b-1",
+                    "scope": "CONFIG",
+                    "scope_type": "team",
+                    "scope_id": "team-a",
+                    "budget_usd": Decimal(1000),
+                    "alert_thresholds": [50, 80, 100],
+                    "alerts_sent": [],
+                }
+            ]
         }
         mock_usage_table.get_item.return_value = {"Item": {"total_cost_usd": Decimal(550)}}
 
         check_and_publish_alerts([_metric(cost_usd=10.0)])
 
-        # Verify update_item was called to persist alerts_sent
+        # Verify update_item was called to persist alerts_sent, keyed by the real
+        # primary key carried on the queried item (issue #261): budget_id + scope.
         mock_budgets_table.update_item.assert_called_once()
         update_call = mock_budgets_table.update_item.call_args
+        assert update_call[1]["Key"] == {"budget_id": "b-1", "scope": "CONFIG"}
         assert update_call[1]["ExpressionAttributeValues"][":as"] == [50]
 
     @patch("cost_attribution.handler.dynamodb")

--- a/tests/test_gwcore.py
+++ b/tests/test_gwcore.py
@@ -197,7 +197,7 @@ def test_build_principal_from_authorizer_claims() -> None:
             "authorizer": {
                 "claims": _claims(
                     "https://gateway.internal/invoke",
-                    **{"custom:team": "ml-platform", "custom:tenant_tier": "premium"},
+                    **{"custom:team": "ml-platform", "custom:tenant_tier": "high"},
                 )
             }
         }
@@ -205,7 +205,7 @@ def test_build_principal_from_authorizer_claims() -> None:
     p = auth.build_principal(event)
     assert p.sub == "user-1"
     assert p.team == "ml-platform"
-    assert p.tenant_tier == "premium"
+    assert p.tenant_tier == "high"
     assert "https://gateway.internal/invoke" in p.scopes
 
 
@@ -239,11 +239,11 @@ def test_admin_alias_legacy_and_canonical() -> None:
 
 
 def test_authorize_scope_and_tier() -> None:
-    p = auth._principal_from_claims(_claims("scope-x", **{"custom:tenant_tier": "premium"}))
+    p = auth._principal_from_claims(_claims("scope-x", **{"custom:tenant_tier": "high"}))
     assert auth.authorize(p, scopes=["scope-x"])
     assert not auth.authorize(p, scopes=["scope-y"])
-    assert auth.authorize(p, tiers=["premium", "enterprise"])
-    assert not auth.authorize(p, tiers=["free"])
+    assert auth.authorize(p, tiers=["high", "unlimited"])
+    assert not auth.authorize(p, tiers=["sandbox"])
 
 
 def test_authorize_require_all_scopes() -> None:

--- a/tests/test_team_registration.py
+++ b/tests/test_team_registration.py
@@ -273,8 +273,8 @@ class TestRegisterTeam:
 
     @patch("team_registration.routes.dynamodb")
     @patch("team_registration.routes.cognito")
-    def test_free_tier_budget(self, mock_cognito: MagicMock, mock_dynamodb: MagicMock) -> None:
-        """Free tier registration should seed a $10 budget."""
+    def test_sandbox_tier_budget(self, mock_cognito: MagicMock, mock_dynamodb: MagicMock) -> None:
+        """Sandbox tier registration should seed a $25 budget."""
         mock_cognito.create_user_pool_client.return_value = _make_cognito_response()
         mock_table = MagicMock()
         mock_table.query.return_value = {"Items": []}
@@ -284,20 +284,25 @@ class TestRegisterTeam:
             "POST",
             "/teams",
             body={
-                "team_name": "free-team",
-                "contact_email": "free@example.com",
-                "tier": "free",
+                "team_name": "sandbox-team",
+                "contact_email": "sandbox@example.com",
+                "tier": "sandbox",
             },
         )
         result = handler(event)
 
         assert result["statusCode"] == 201
 
-        # Check the budget put_item call — second put_item is the budget record
+        # Check the budget put_item call — second put_item is the budget record.
+        # Seeded on the real gateway-budgets schema (issue #261): the cap lives in
+        # ``budget_usd`` with the entity in scope_type/scope_id and scope="CONFIG".
         calls = mock_table.put_item.call_args_list
         assert len(calls) == 2
         budget_item = calls[1].kwargs["Item"]
-        assert budget_item["monthly_budget_usd"] == Decimal(10)
+        assert budget_item["budget_usd"] == Decimal(25)
+        assert budget_item["scope"] == "CONFIG"
+        assert budget_item["scope_type"] == "team"
+        assert budget_item["scope_id"] == "sandbox-team"
 
 
 # ── List teams tests ─────────────────────────────────────────────────────────
@@ -553,10 +558,10 @@ class TestModels:
             RegisterTeamRequest(team_name="", contact_email="a@b.com")
 
     def test_tier_budget_defaults(self) -> None:
-        assert TIER_BUDGET_DEFAULTS[Tier.FREE] == 10
-        assert TIER_BUDGET_DEFAULTS[Tier.STANDARD] == 1000
-        assert TIER_BUDGET_DEFAULTS[Tier.PREMIUM] == 10000
-        assert TIER_BUDGET_DEFAULTS[Tier.ENTERPRISE] == 100000
+        assert TIER_BUDGET_DEFAULTS[Tier.SANDBOX] == 25
+        assert TIER_BUDGET_DEFAULTS[Tier.STANDARD] == 100
+        assert TIER_BUDGET_DEFAULTS[Tier.HIGH] == 1000
+        assert TIER_BUDGET_DEFAULTS[Tier.UNLIMITED] == 10000
 
     def test_credentials_response(self) -> None:
         resp = CredentialsResponse(

--- a/tests/test_usage_api.py
+++ b/tests/test_usage_api.py
@@ -87,10 +87,10 @@ def _make_usage_item(
     total_cost_usd: str = "1.50",
     request_count: int = 5,
 ) -> dict[str, Any]:
-    """Build a DynamoDB usage item."""
+    """Build a DynamoDB usage item (real gateway-usage schema, issue #261)."""
     return {
-        "pk": f"USAGE#TEAM#{team}",
-        "sk": f"PERIOD#{period}",
+        "scope_id": f"team#{team}",
+        "period_date": period,
         "total_tokens": total_tokens,
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
@@ -111,10 +111,10 @@ def _make_model_item(
     total_cost_usd: str = "0.75",
     request_count: int = 3,
 ) -> dict[str, Any]:
-    """Build a DynamoDB model-level usage item."""
+    """Build a DynamoDB model-level usage item (real gateway-usage schema)."""
     return {
-        "pk": f"USAGE#TEAM#{team}#MODEL#{model}",
-        "sk": f"PERIOD#{period}",
+        "scope_id": f"team#{team}#model#{model}",
+        "period_date": period,
         "total_tokens": total_tokens,
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
@@ -127,12 +127,24 @@ def _make_budget_item(
     team: str,
     monthly_budget_usd: str = "100.00",
 ) -> dict[str, Any]:
-    """Build a DynamoDB budget config item."""
+    """Build a DynamoDB budget config item (real gateway-budgets schema, #261).
+
+    budget_admin writes the cap as ``budget_usd`` and looks a budget up by team
+    via the ``scope-index`` GSI (scope == "CONFIG", scope_id == team), so the
+    handler now queries rather than get_item. See ``_budget_query_result``.
+    """
     return {
-        "pk": f"BUDGET#{team}",
-        "sk": "CONFIG",
-        "monthly_budget_usd": Decimal(monthly_budget_usd),
+        "budget_id": f"b-{team}",
+        "scope": "CONFIG",
+        "scope_type": "team",
+        "scope_id": team,
+        "budget_usd": Decimal(monthly_budget_usd),
     }
+
+
+def _budget_query_result(team: str, monthly_budget_usd: str = "100.00") -> dict[str, Any]:
+    """Wrap a budget config item as a scope-index query response."""
+    return {"Items": [_make_budget_item(team, monthly_budget_usd)]}
 
 
 def _parse_body(result: dict[str, Any]) -> dict[str, Any]:
@@ -305,7 +317,7 @@ class TestItemToUsagePeriod:
         assert period.request_count == 5
 
     def test_missing_fields_default_to_zero(self) -> None:
-        item = {"pk": "USAGE#TEAM#t", "sk": "PERIOD#2026-03"}
+        item = {"scope_id": "team#t", "period_date": "2026-03"}
         period = _item_to_usage_period(item, "2026-03")
         assert period.total_tokens == 0
         assert period.total_cost_usd == Decimal(0)
@@ -321,15 +333,15 @@ class TestItemToModelUsage:
         assert mu.total_cost_usd == Decimal("0.75")
 
     def test_returns_none_for_missing_model_marker(self) -> None:
-        item = {"pk": "USAGE#TEAM#test-team", "sk": "PERIOD#2026-03"}
+        item = {"scope_id": "team#test-team", "period_date": "2026-03"}
         assert _item_to_model_usage(item) is None
 
     def test_returns_none_for_empty_model_name(self) -> None:
-        item = {"pk": "USAGE#TEAM#test-team#MODEL#", "sk": "PERIOD#2026-03"}
+        item = {"scope_id": "team#test-team#model#", "period_date": "2026-03"}
         assert _item_to_model_usage(item) is None
 
-    def test_returns_none_for_no_pk(self) -> None:
-        item = {"sk": "PERIOD#2026-03"}
+    def test_returns_none_for_no_scope_id(self) -> None:
+        item = {"period_date": "2026-03"}
         assert _item_to_model_usage(item) is None
 
 
@@ -497,11 +509,8 @@ class TestHandlerHistory:
         def get_item_side_effect(**kwargs: Any) -> dict[str, Any]:
             nonlocal call_count
             call_count += 1
-            key = kwargs.get("Key", {})
-            pk = key.get("pk", "")
-            if pk.startswith("BUDGET#"):
-                return {}
-            # Return data for the current period query and for history
+            # Usage rows are keyed by scope_id/period_date (issue #261); budget
+            # lookups go through the scope-index query, not get_item.
             return {"Item": _make_usage_item("test-team", period, total_tokens=1000 * call_count)}
 
         def table_router(name: str) -> MagicMock:
@@ -511,7 +520,7 @@ class TestHandlerHistory:
 
         mock_ddb.Table.side_effect = table_router
         mock_usage_table.get_item.side_effect = get_item_side_effect
-        mock_budgets_table.get_item.return_value = {}
+        mock_budgets_table.query.return_value = {"Items": []}
 
         event = _make_event(team="test-team", history="3")
         result = handler(event)
@@ -544,10 +553,6 @@ class TestHandlerHistory:
 
         def get_item_side_effect(**kwargs: Any) -> dict[str, Any]:
             nonlocal history_call
-            key = kwargs.get("Key", {})
-            pk = key.get("pk", "")
-            if pk.startswith("BUDGET#"):
-                return {}
             history_call += 1
             # Return data for 1st and 3rd calls, empty for 2nd
             if history_call == 2:
@@ -561,7 +566,7 @@ class TestHandlerHistory:
 
         mock_ddb.Table.side_effect = table_router
         mock_usage_table.get_item.side_effect = get_item_side_effect
-        mock_budgets_table.get_item.return_value = {}
+        mock_budgets_table.query.return_value = {"Items": []}
 
         event = _make_event(team="test-team", history="3")
         result = handler(event)
@@ -595,7 +600,7 @@ class TestHandlerModels:
             "Item": _make_usage_item("test-team", period, total_cost_usd="15.00"),
         }
         mock_usage_table.scan.return_value = {"Items": model_items}
-        mock_budgets_table.get_item.return_value = {}
+        mock_budgets_table.query.return_value = {"Items": []}
 
         def table_router(name: str) -> MagicMock:
             if "budget" in name.lower():
@@ -629,7 +634,7 @@ class TestHandlerModels:
             "Item": _make_usage_item("test-team", period, total_cost_usd="12.50"),
         }
         mock_usage_table.scan.return_value = {"Items": model_items}
-        mock_budgets_table.get_item.return_value = {}
+        mock_budgets_table.query.return_value = {"Items": []}
 
         def table_router(name: str) -> MagicMock:
             if "budget" in name.lower():
@@ -678,10 +683,10 @@ class TestHandlerModels:
             "Item": _make_usage_item("test-team", period, total_cost_usd="15.00"),
         }
         mock_usage_table.scan.side_effect = [
-            {"Items": page1_items, "LastEvaluatedKey": {"pk": "cursor"}},
+            {"Items": page1_items, "LastEvaluatedKey": {"scope_id": "cursor"}},
             {"Items": page2_items},
         ]
-        mock_budgets_table.get_item.return_value = {}
+        mock_budgets_table.query.return_value = {"Items": []}
 
         def table_router(name: str) -> MagicMock:
             if "budget" in name.lower():
@@ -714,9 +719,7 @@ class TestHandlerBudgetUtilization:
         mock_usage_table.get_item.return_value = {
             "Item": _make_usage_item("test-team", period, total_cost_usd="75.00"),
         }
-        mock_budgets_table.get_item.return_value = {
-            "Item": _make_budget_item("test-team", "100.00"),
-        }
+        mock_budgets_table.query.return_value = _budget_query_result("test-team", "100.00")
 
         def table_router(name: str) -> MagicMock:
             if "budget" in name.lower():
@@ -742,7 +745,7 @@ class TestHandlerBudgetUtilization:
         mock_budgets_table = MagicMock()
 
         mock_usage_table.get_item.return_value = {"Item": _make_usage_item("test-team", period)}
-        mock_budgets_table.get_item.return_value = {}  # No budget config
+        mock_budgets_table.query.return_value = {"Items": []}  # No budget config
 
         def table_router(name: str) -> MagicMock:
             if "budget" in name.lower():
@@ -770,9 +773,7 @@ class TestHandlerBudgetUtilization:
         mock_usage_table.get_item.return_value = {
             "Item": _make_usage_item("test-team", period, total_cost_usd="50.00"),
         }
-        mock_budgets_table.get_item.return_value = {
-            "Item": _make_budget_item("test-team", "0"),
-        }
+        mock_budgets_table.query.return_value = _budget_query_result("test-team", "0")
 
         def table_router(name: str) -> MagicMock:
             if "budget" in name.lower():
@@ -796,9 +797,7 @@ class TestHandlerBudgetUtilization:
         mock_budgets_table = MagicMock()
 
         mock_usage_table.get_item.return_value = {}  # No usage item
-        mock_budgets_table.get_item.return_value = {
-            "Item": _make_budget_item("test-team", "100.00"),
-        }
+        mock_budgets_table.query.return_value = _budget_query_result("test-team", "100.00")
 
         def table_router(name: str) -> MagicMock:
             if "budget" in name.lower():
@@ -848,7 +847,7 @@ class TestHandlerDDBErrors:
         mock_usage_table.get_item.return_value = {
             "Item": _make_usage_item("test-team", period, total_cost_usd="50.00"),
         }
-        mock_budgets_table.get_item.side_effect = _ddb_error()
+        mock_budgets_table.query.side_effect = _ddb_error()
 
         def table_router(name: str) -> MagicMock:
             if "budget" in name.lower():
@@ -894,7 +893,7 @@ class TestHandlerDDBErrors:
 
         mock_ddb.Table.side_effect = table_router
         mock_usage_table.get_item.side_effect = get_item_side_effect
-        mock_budgets_table.get_item.return_value = {}
+        mock_budgets_table.query.return_value = {"Items": []}
 
         event = _make_event(team="test-team", history="3")
         result = handler(event)
@@ -913,7 +912,7 @@ class TestHandlerDDBErrors:
             "Item": _make_usage_item("test-team", period),
         }
         mock_usage_table.scan.side_effect = _ddb_error()
-        mock_budgets_table.get_item.return_value = {}
+        mock_budgets_table.query.return_value = {"Items": []}
 
         def table_router(name: str) -> MagicMock:
             if "budget" in name.lower():
@@ -960,9 +959,7 @@ class TestHandlerCombined:
 
         mock_usage_table.get_item.return_value = {"Item": usage_item}
         mock_usage_table.scan.return_value = {"Items": model_items}
-        mock_budgets_table.get_item.return_value = {
-            "Item": _make_budget_item("test-team", "200.00"),
-        }
+        mock_budgets_table.query.return_value = _budget_query_result("test-team", "200.00")
 
         def table_router(name: str) -> MagicMock:
             if "budget" in name.lower():
@@ -1001,7 +998,7 @@ class TestHandlerCombined:
         mock_usage_table.scan.return_value = {
             "Items": [_make_model_item("test-team", "gpt-4", period)],
         }
-        mock_budgets_table.get_item.return_value = {}
+        mock_budgets_table.query.return_value = {"Items": []}
 
         def table_router(name: str) -> MagicMock:
             if "budget" in name.lower():

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,7 @@ dev = [
     { name = "boto3-stubs" },
     { name = "commitizen" },
     { name = "hypothesis" },
+    { name = "moto" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -48,6 +49,7 @@ dev = [
     { name = "boto3-stubs", specifier = ">=1.43.40" },
     { name = "commitizen", specifier = ">=4.16.4" },
     { name = "hypothesis", specifier = ">=6.156.1" },
+    { name = "moto", specifier = ">=5.2.2" },
     { name = "pyright", specifier = ">=1.1.411" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
@@ -162,6 +164,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7f/81/79693e833291c00dc89ee610e5e915381b6f08233912e28df50106840780/botocore_stubs-1.43.14.tar.gz", hash = "sha256:9e3bc1fdd51da7473f0df726c82747a1b0ae913449d629659765c247fecc2039", size = 42738, upload-time = "2026-05-25T06:06:37.484Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/89/ca/f017727b11895908c5dedc829cf2ec35e0c4b2a26ba875db325fef2cefdf/botocore_stubs-1.43.14-py3-none-any.whl", hash = "sha256:fb98f1475c92fd718644e786b5c543a20f1b1f610e89e0a7191c3f1f429c75aa", size = 67093, upload-time = "2026-05-25T06:06:34.532Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
 ]
 
 [[package]]
@@ -632,6 +643,24 @@ wheels = [
 ]
 
 [[package]]
+name = "moto"
+version = "5.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "cryptography" },
+    { name = "requests" },
+    { name = "responses" },
+    { name = "werkzeug" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/63/d944f387582cc53f53febbff2b3fa36a6d2ed7c1feef8990bf646cfa9cba/moto-5.2.2.tar.gz", hash = "sha256:aac8023a429e125e91c91f8f4730a67b54f518cda587352f7e67252fe3168f75", size = 8678761, upload-time = "2026-06-06T18:57:54.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/45/13cff46f4f617a6e97e1d497d75abd913e250bb4c823a4985668c6e593e4/moto-5.2.2-py3-none-any.whl", hash = "sha256:3817f1e39721ca833579b921e53e3b68547ace6a34d848c9486fbb5905808de9", size = 6698689, upload-time = "2026-06-06T18:57:51.435Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -889,6 +918,35 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "responses"
+version = "0.26.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/1a/4af3e6d659394b809838490b144e4ab8d7ed3b9fecc7ca78f5d2f79b1a3d/responses-0.26.2.tar.gz", hash = "sha256:9c9259b46a8349197edebf43cfa68a87e1a2802ef503ff8b2fecbabc0b45afd8", size = 84030, upload-time = "2026-07-03T16:44:50.325Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/28/693e1d9ebf72baa062ded80d837a035b86ce75eda5a269379e9e2b1008a8/responses-0.26.2-py3-none-any.whl", hash = "sha256:6fdfeabd58e5ec473b98dfe02e6d46d3173bd8dd573eff2ccccf1a05a5135364", size = 35609, upload-time = "2026-07-03T16:44:49.1Z" },
+]
+
+[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1063,6 +1121,18 @@ wheels = [
 ]
 
 [[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
 name = "wrapt"
 version = "2.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1113,4 +1183,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
     { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
     { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
 ]


### PR DESCRIPTION
Resolves #260, #261, #262, #263 in one sprint.

The two bug issues (#260, #261) looked like localized fixes but an adversarial validation pass proved the narrow fixes **passed tests yet were no-ops in production** — every service mocks DynamoDB in tests, hiding a subsystem-wide schema incoherence. Both are now fixed and verified end-to-end.

## #260 — Unify tier defaults (single source of truth)
- New `src/gwcore/tiers.py` — canonical `Tier` enum + `TIER_DEFAULTS` + helpers; the 4 duplicated definitions in `team_registration`, `budget_enforcement`, `budget_admin`, `cost_attribution` now import from it.
- **Vocabulary changed** from SaaS pricing (`free/premium/enterprise`) to internal quota classes (`sandbox/standard/high/unlimited`) — this gateway is deployed by orgs for their own teams, not sold as a product.
- **Closed the code↔infra seam** (found by adversarial review): the Terraform `TIER_DEFAULTS` env still shipped `premium` and *overrode* the Python default at runtime, so a `high` tenant silently got `standard` limits. Renamed `premium`→`high` in `variables.tf` and removed the dead legacy `tier_default_*` vars + wiring + fallback.

## #261 — Unify budgets/usage DynamoDB key schema
- Only **two** physical tables exist (`gateway-budgets`, `gateway-usage`) with fixed key schemas, but every service except `budget_admin` was written against a **phantom `pk`/`sk` single-table design that does not exist on the deployed tables**. In production the whole budget/usage/rate-limit path raised `ValidationException` and failed open (`budget-check-degraded` on every request).
- Converted `budget_enforcement`, `cost_attribution`, `usage_api`, `rate_limiter`, `chargeback_report`, and the `team_registration` budget seed onto the real schema (`scope_id`/`period_date` for usage; `budget_id`/`scope` + `scope-index` GSI for budgets).
- Added a **moto-backed end-to-end round-trip test** proving admin-created budgets are now enforced against accumulated usage — it fails with the exact `ValidationException` if any read is reverted to `pk`/`sk`.

## #262 — Consolidate Checkov waivers
- Moved the 6 inline-only `skip_check` codes into `.checkov.yml` with grounded per-code rationale (all 28 now live there with justifications).
- CI now uses `config_file: .checkov.yml` instead of an inline `skip_check` string, so CI and local `mise run security:iac` converge on one source of truth.
- `checkov`: **210 passed, 0 failed, 29 skipped**.

## #263 — engineering-docs tracking (treated as an implementation issue)
- Verified each of the 5 omitted docs' rationale against current code. One precondition had **flipped**: an admin CLI now exists (`clients/admin_cli`, cyclopts). Generated `engineering-docs/reference/cli.md` documenting the full command tree; fixed the now-false "ships no CLI" claim in `public-api.md`; updated the README omit section. The other 4 rationales still hold.

## Verification
- **606 tests pass** (was 597 at sprint start; +9 net incl. the round-trip suite).
- `ruff check` / `ruff format --check` / `pyright src/` / `terraform fmt -check` / `terraform validate` / `actionlint` / `checkov` — all green.
- Round-trip test verified as a genuine guard (fails on revert, passes on restore).

## Follow-ups (non-blocking, not in this PR)
- Remove redundant inline `#checkov:skip=` comments in Terraform now duplicated by `.checkov.yml`.
- Add DLQs to async-invoked audit-pipeline Lambdas (CKV_AWS_116) rather than blanket-suppressing.
- Enforce one-budget-per-`(scope_type, scope_id)` at write time, or make `_get_budget_record` deterministic (currently returns `items[0]` from the GSI).
- `budget_admin` quarterly/annual `period` is currently enforced as monthly — carry `period` through or reject non-monthly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)